### PR TITLE
feat: Keycloak SSO + Google Sign-In + Role-Based Access Control

### DIFF
--- a/environment.ts
+++ b/environment.ts
@@ -1,7 +1,10 @@
 // environment.ts (Development)
 export const environment = {
   production: false,
-  //apiUrl: 'http://104.154.198.60:8080/api/'
-  apiUrl: 'http://localhost:8080/api/'
-
+  apiUrl: 'http://localhost:8080/api/',
+  keycloak: {
+    url: 'http://localhost:9080',
+    realm: 'harmony',
+    clientId: 'totolocator-frontend'
+  }
 };

--- a/environment.ts
+++ b/environment.ts
@@ -8,3 +8,4 @@ export const environment = {
     clientId: 'totolocator-frontend'
   }
 };
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "devextreme": "^24.2.3",
         "devextreme-angular": "^24.2.3",
         "express": "^4.18.2",
+        "keycloak-js": "^26.2.4",
         "leaflet": "^1.9.4",
         "ng-apexcharts": "1.7.6",
         "ngx-pagination": "^6.0.1",
@@ -4940,7 +4941,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4961,7 +4961,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4982,7 +4981,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5003,7 +5001,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5024,7 +5021,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5045,7 +5041,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5066,7 +5061,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5087,7 +5081,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5108,7 +5101,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5129,7 +5121,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5150,7 +5141,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5171,7 +5161,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5192,7 +5181,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10538,6 +10526,15 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/keycloak-js": {
+      "version": "26.2.4",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.2.4.tgz",
+      "integrity": "sha512-PnXpR3ubETGOt0B/Qt2lxmPbkZr5bc3vlQsOqDoTPPQsZRp7JjhTKxlJ187uWh8qJhvBab6Gsjb06a8ayOPfuw==",
+      "license": "Apache-2.0",
+      "workspaces": [
+        "test"
+      ]
     },
     "node_modules/kind-of": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "devextreme": "^24.2.3",
     "devextreme-angular": "^24.2.3",
     "express": "^4.18.2",
+    "keycloak-js": "^26.2.4",
     "leaflet": "^1.9.4",
     "ng-apexcharts": "1.7.6",
     "ngx-pagination": "^6.0.1",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,8 +1,11 @@
-import { NgModule } from '@angular/core';
+import { APP_INITIALIZER, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { HttpClient, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
 import { NgApexchartsModule } from 'ng-apexcharts';
+import { NgxPermissionsModule } from 'ngx-permissions';
+import { AuthService } from './services/auth.service';
+import { authInterceptor } from './interceptors/auth.interceptor';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -46,5 +49,17 @@ export function HttpLoaderFactory(http: HttpClient): any {
                 useFactory: HttpLoaderFactory,
                 deps: [HttpClient],
             },
-        })], providers: [provideHttpClient(withInterceptorsFromDi())] })
+        }),
+        NgxPermissionsModule.forRoot(),
+    ],
+    providers: [
+        provideHttpClient(withInterceptors([authInterceptor])),
+        {
+            provide: APP_INITIALIZER,
+            useFactory: (auth: AuthService) => () => auth.init(),
+            deps: [AuthService],
+            multi: true,
+        },
+    ],
+})
 export class AppModule {}

--- a/src/app/interceptors/auth.interceptor.ts
+++ b/src/app/interceptors/auth.interceptor.ts
@@ -1,0 +1,11 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { AuthService } from '../services/auth.service';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const token = inject(AuthService).getToken();
+  if (token) {
+    req = req.clone({ setHeaders: { Authorization: `Bearer ${token}` } });
+  }
+  return next(req);
+};

--- a/src/app/layouts/full/full.component.ts
+++ b/src/app/layouts/full/full.component.ts
@@ -5,7 +5,9 @@ import { MatSidenav } from '@angular/material/sidenav';
 import { CoreService } from 'src/app/services/core.service';
 import { AppSettings } from 'src/app/app.config';
 import { navItems } from './vertical/sidebar/sidebar-data';
+import { NavItem } from './vertical/sidebar/nav-item/nav-item';
 import { NavService } from '../../services/nav.service';
+import { AuthService } from '../../services/auth.service';
 import { NgScrollbarModule } from 'ngx-scrollbar';
 import {
   AppSearchDialogComponent,
@@ -46,7 +48,7 @@ const BELOWMONITOR = 'screen and (max-width: 1023px)';
     encapsulation: ViewEncapsulation.None
 })
 export class FullComponent implements OnInit {
-  navItems = navItems;
+  navItems: NavItem[] = [];
   @ViewChild('leftsidenav')
   public sidenav: MatSidenav;
   resView = false;
@@ -71,7 +73,8 @@ export class FullComponent implements OnInit {
     private settings: CoreService,
     private mediaMatcher: MediaMatcher,
     private navService: NavService,
-    private breakpointObserver: BreakpointObserver
+    private breakpointObserver: BreakpointObserver,
+    private authService: AuthService,
   ) {
     this.htmlElement = document.querySelector('html')!;
     this.layoutChangesSubscription = this.breakpointObserver
@@ -92,7 +95,12 @@ export class FullComponent implements OnInit {
     this.receiveOptions(this.options);
   }
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    const userRoles = this.authService.getRoles();
+    this.navItems = navItems.filter(
+      (item) => !item.roles || item.roles.some((r) => userRoles.includes(r)),
+    );
+  }
 
   ngOnDestroy() {
     this.layoutChangesSubscription.unsubscribe();

--- a/src/app/layouts/full/vertical/header/header.component.html
+++ b/src/app/layouts/full/vertical/header/header.component.html
@@ -238,13 +238,12 @@
       </div>
 
       <div class="p-y-12 p-x-32">
-        <a
-          [routerLink]="['/authentication/side-login']"
+        <button
           mat-stroked-button
           color="primary"
           class="w-100"
-        >Logout</a
-        >
+          (click)="logout()"
+        >Logout</button>
       </div>
     </ng-scrollbar>
   </mat-menu>

--- a/src/app/layouts/full/vertical/header/header.component.ts
+++ b/src/app/layouts/full/vertical/header/header.component.ts
@@ -8,6 +8,7 @@ import {
 import { CoreService } from 'src/app/services/core.service';
 import { MatDialog } from '@angular/material/dialog';
 import { navItems } from '../sidebar/sidebar-data';
+import { AuthService } from 'src/app/services/auth.service';
 import { TranslateService } from '@ngx-translate/core';
 import { RouterModule } from '@angular/router';
 import { MaterialModule } from 'src/app/material.module';
@@ -106,9 +107,14 @@ export class HeaderComponent {
   constructor(
     private vsidenav: CoreService,
     public dialog: MatDialog,
-    private translate: TranslateService
+    private translate: TranslateService,
+    private authService: AuthService,
   ) {
     translate.setDefaultLang('en');
+  }
+
+  logout(): void {
+    this.authService.logout();
   }
 
   openDialog() {

--- a/src/app/layouts/full/vertical/sidebar/nav-item/nav-item.ts
+++ b/src/app/layouts/full/vertical/sidebar/nav-item/nav-item.ts
@@ -12,4 +12,5 @@ export interface NavItem {
     route?: string;
     children?: NavItem[];
     ddType?: string;
+    roles?: string[];
 }

--- a/src/app/layouts/full/vertical/sidebar/sidebar-data.ts
+++ b/src/app/layouts/full/vertical/sidebar/sidebar-data.ts
@@ -8,79 +8,93 @@ export const navItems: NavItem[] = [
     displayName: 'Harmony Admin',
     iconName: 'chart-pie',
     route: '/dashboards/harmony-admin',
+    roles: ['ROLE_ADMIN'],
   },
   {
     displayName: 'School Admin',
     iconName: 'chart-pie',
     route: '/dashboards/school-admin',
+    roles: ['ROLE_ADMIN', 'ROLE_USER'],
   },
   {
     displayName: 'Driver Dashboard',
     iconName: 'chart-pie',
     route: '/dashboards/driver',
+    roles: ['ROLE_ADMIN', 'ROLE_DRIVER'],
   },
   {
     displayName: 'Guardian Dashboard',
     iconName: 'chart-pie',
     route: '/dashboards/guardian',
+    roles: ['ROLE_ADMIN', 'ROLE_GUARDIAN'],
   },
   {
     navCap: 'Pages',
   },
-  // =========== Beginning of actual sidebar ==========
   {
     displayName: 'Organizations',
     iconName: 'certificate',
     route: 'apps/organizations',
+    roles: ['ROLE_ADMIN'],
   },
   {
     displayName: 'Schools',
     iconName: 'certificate',
     route: 'apps/schools',
+    roles: ['ROLE_ADMIN', 'ROLE_USER'],
   },
   {
     displayName: 'Staff',
     iconName: 'users',
     route: 'apps/staff',
+    roles: ['ROLE_ADMIN', 'ROLE_USER'],
   },
   {
     displayName: 'Guardians',
     iconName: 'mood-boy',
     route: 'apps/guardians',
+    roles: ['ROLE_ADMIN', 'ROLE_GUARDIAN'],
   },
   {
     displayName: 'Students',
     iconName: 'school',
     route: 'apps/students',
+    roles: ['ROLE_ADMIN', 'ROLE_USER', 'ROLE_GUARDIAN'],
   },
   {
     displayName: 'Drivers',
     iconName: 'steering-wheel',
     route: 'apps/drivers',
+    roles: ['ROLE_ADMIN', 'ROLE_DRIVER'],
   },
   {
     displayName: 'Vehicles',
     iconName: 'car',
     route: 'apps/vehicles',
+    roles: ['ROLE_ADMIN', 'ROLE_DRIVER'],
   },
   {
     displayName: 'Trips',
     iconName: 'road',
     route: 'apps/trips',
+    roles: ['ROLE_ADMIN', 'ROLE_DRIVER'],
   },
   {
     displayName: 'Terminals',
     iconName: 'device-ipad',
     route: 'apps/terminals',
+    roles: ['ROLE_ADMIN'],
   },
   {
     displayName: 'Invoices',
     iconName: 'file-invoice',
     route: 'apps/invoices',
+    roles: ['ROLE_ADMIN'],
   },
   {
     displayName: 'Notifications',
     iconName: 'message-2',
     route: 'apps/notifications',
-  }
+    roles: ['ROLE_ADMIN', 'ROLE_USER', 'ROLE_GUARDIAN', 'ROLE_DRIVER'],
+  },
 ];

--- a/src/app/pages/apps/apps.module.ts
+++ b/src/app/pages/apps/apps.module.ts
@@ -9,7 +9,8 @@ import { NgxPermissionsModule } from 'ngx-permissions';
 import { NgxPaginationModule } from 'ngx-pagination';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { NgApexchartsModule } from 'ng-apexcharts';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { authInterceptor } from '../../interceptors/auth.interceptor';
 import { AngularEditorModule } from '@kolkov/angular-editor';
 
 // icons
@@ -87,5 +88,5 @@ import {GoogleMapsModule} from "@angular/google-maps";
             useFactory: adapterFactory,
         }),
         MatNativeDateModule,
-        NgScrollbarModule], providers: [DatePipe, provideHttpClient(withInterceptorsFromDi())] })
+        NgScrollbarModule], providers: [DatePipe, provideHttpClient(withInterceptors([authInterceptor]))] })
 export class AppsModule {}

--- a/src/app/pages/apps/reusable/CrudActions.ts
+++ b/src/app/pages/apps/reusable/CrudActions.ts
@@ -1,5 +1,5 @@
 import {MatDialog} from "@angular/material/dialog";
-import { HttpClient, HttpHeaders } from "@angular/common/http";
+import { HttpClient } from "@angular/common/http";
 import {EntityAction} from "./EntityAction";
 import {environment} from "../../../../../environment";
 import {SchoolViewComponent} from "../schools/school-view/school-view.component";
@@ -7,10 +7,6 @@ import {Observable} from "rxjs";
 import {IForm} from "../forms/interfaces/IForm";
 
 export class CrudActions {
-  headers = new HttpHeaders({
-    'Content-Type': 'application/json',
-    'Authorization': `Bearer ${localStorage.getItem('token')}`
-  })
 
   constructor(public dialog: MatDialog, private http: HttpClient) {
   }
@@ -37,9 +33,7 @@ export class CrudActions {
    * @param entity
    */
   getRecord(entity: EntityAction): Observable<any> {
-    return this.http.get(environment.apiUrl.concat(entity.name).concat("?page=0&size=20"), {
-      headers: this.headers
-    });
+    return this.http.get(environment.apiUrl.concat(entity.name).concat("?page=0&size=20"));
   }
 
 
@@ -88,7 +82,7 @@ export class CrudActions {
    */
   addRecord(entity: EntityAction): Observable<any> {
     console.log("Record added: ", entity);
-    return this.http.post(environment.apiUrl.concat(entity.name),  entity.data, {headers: this.headers})
+    return this.http.post(environment.apiUrl.concat(entity.name), entity.data)
   }
 
   /**
@@ -142,7 +136,7 @@ export class CrudActions {
    * @param entity
    */
   updateRecord(entity: EntityAction): Observable<any> {
-    return this.http.patch(environment.apiUrl.concat(entity.name).concat(`/${entity.id}`), entity.data, {headers: this.headers});
+    return this.http.patch(environment.apiUrl.concat(entity.name).concat(`/${entity.id}`), entity.data);
   }
 
   /**
@@ -198,7 +192,7 @@ export class CrudActions {
    * @param entity
    */
   deleteRecord(entity: EntityAction): Observable<any> {
-    return this.http.delete(environment.apiUrl.concat(entity.name).concat(`/${entity.id}`), {headers: this.headers});
+    return this.http.delete(environment.apiUrl.concat(entity.name).concat(`/${entity.id}`));
   }
 
   /**
@@ -206,7 +200,7 @@ export class CrudActions {
    * @param record
    */
   onFilterRecord(record: EntityAction): Observable<any> {
-    return this.http.get(environment.apiUrl.concat(record.name).concat("?name.contains=" + record.data), {headers: this.headers});
+    return this.http.get(environment.apiUrl.concat(record.name).concat("?name.contains=" + record.data));
   }
 
 

--- a/src/app/pages/apps/terminals/terminal-view/terminal-view.component.ts
+++ b/src/app/pages/apps/terminals/terminal-view/terminal-view.component.ts
@@ -1,7 +1,7 @@
 import {AfterViewInit, Component, OnInit} from '@angular/core';
 import * as L from 'leaflet';
 import {ActivatedRoute} from "@angular/router";
-import {HttpClient, HttpHeaders} from "@angular/common/http";
+import {HttpClient} from "@angular/common/http";
 import {environment} from "../../../../../../environment";
 
 
@@ -11,11 +11,6 @@ import {environment} from "../../../../../../environment";
   standalone: false
 })
 export class TerminalViewComponent implements AfterViewInit, OnInit {
-  headers = new HttpHeaders({
-    'Content-Type': 'application/json',
-    'Authorization': `Bearer ${localStorage.getItem('token')}`
-  })
-
   terminalId: any;
   map: any;
   marker: any;
@@ -136,9 +131,7 @@ export class TerminalViewComponent implements AfterViewInit, OnInit {
    * @param id
    */
   fetchTerminalInfo(id: number) {
-    this.http.get(environment.apiUrl.concat("terminals/" + id), {
-      headers: this.headers
-    })
+    this.http.get(environment.apiUrl.concat("terminals/" + id))
     .subscribe((res: any) => {
       console.log("Getting terminal information: {}", res)
       this.terminal = res;
@@ -152,10 +145,7 @@ export class TerminalViewComponent implements AfterViewInit, OnInit {
    * @param id
    */
   async fetchVehicleInfo(id: number) {
-    await this.http.get(environment.apiUrl.concat("fleets?terminalId.equald=" + id), {
-        headers: this.headers
-      }
-    )
+    await this.http.get(environment.apiUrl.concat("fleets?terminalId.equald=" + id))
     .subscribe((res: any) => {
       console.log("Getting vehicle information: {}", res)
       this.vehicle = res[0];

--- a/src/app/pages/apps/trips/student-trip/student-trip.component.ts
+++ b/src/app/pages/apps/trips/student-trip/student-trip.component.ts
@@ -1,6 +1,6 @@
 import {Component, Inject, OnInit, Optional} from '@angular/core';
 import {MAT_DIALOG_DATA, MatDialog, MatDialogRef} from "@angular/material/dialog";
-import {HttpClient, HttpHeaders} from "@angular/common/http";
+import {HttpClient} from "@angular/common/http";
 import {ActivatedRoute, Router} from "@angular/router";
 import {environment} from 'environment';
 
@@ -11,12 +11,6 @@ import {environment} from 'environment';
   standalone: false
 })
 export class StudentTripComponent implements OnInit {
-  headers = new HttpHeaders({
-    'Content-Type': 'application/json',
-    'Authorization': `Bearer ${localStorage.getItem('token')}`
-  })
-
-
   actionPojo = {
     id: 1,
     status: ''
@@ -43,7 +37,7 @@ export class StudentTripComponent implements OnInit {
 
   // Get students on the given trip
   getStudentsOnTrip(tripId: number) {
-    this.http.get(environment.apiUrl.concat("student-trips?tripId.equals=" + tripId + "&page=0&size=20"), {headers: this.headers})
+    this.http.get(environment.apiUrl.concat("student-trips?tripId.equals=" + tripId + "&page=0&size=20"))
     .subscribe((res: any) => {
       this.students = res;
       console.log("Getting students in the trip data: {}", res)
@@ -55,7 +49,7 @@ export class StudentTripComponent implements OnInit {
   applyFilter(event: Event): void {
     const filterValue = (event.target as HTMLInputElement).value;
 
-    this.http.get(environment.apiUrl.concat("student-trips").concat("?student_name.contains=" + filterValue), {headers: this.headers})
+    this.http.get(environment.apiUrl.concat("student-trips").concat("?student_name.contains=" + filterValue))
     .subscribe(res => {
       //this.students = res;
 
@@ -121,7 +115,7 @@ export class StudentTripComponent implements OnInit {
     dialogRef.afterClosed().subscribe((result) => {
       if (result.event === 'Confirm') {
         console.log("Confirmed update of student trip.")
-        this.http.patch(environment.apiUrl + "student-trips/" + this.actionPojo.id, this.actionPojo, {headers: this.headers})
+        this.http.patch(environment.apiUrl + "student-trips/" + this.actionPojo.id, this.actionPojo)
         .subscribe({
           next: (res) => {
             this.dialog.open(DialogBoxComponent, {

--- a/src/app/pages/authentication/auth-guard/AuthGuard.ts
+++ b/src/app/pages/authentication/auth-guard/AuthGuard.ts
@@ -1,25 +1,21 @@
-import {
-  ActivatedRouteSnapshot,
-  CanActivate,
-  Router,
-  RouterStateSnapshot,
-  UrlTree
-} from "@angular/router";
-import {Observable} from "rxjs";
-import {Injectable} from "@angular/core";
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { Observable } from 'rxjs';
+import { Injectable } from '@angular/core';
+import { AuthService } from 'src/app/services/auth.service';
 
-@Injectable({providedIn: 'root',})
+@Injectable({ providedIn: 'root' })
 export class AuthGuard implements CanActivate {
-  constructor(private routes: Router) {
-  }
+  constructor(private router: Router, private authService: AuthService) {}
 
-  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
-    if (localStorage.getItem('token') != null) {
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot,
+  ): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    if (this.authService.getToken()) {
+      this.authService.loadRolesFromToken();
       return true;
-    } else {
-      this.routes.navigate(['/authentication/login']);
-      return false;
     }
+    this.router.navigate(['/authentication/login']);
+    return false;
   }
-
 }

--- a/src/app/pages/authentication/auth-guard/RoleGuard.ts
+++ b/src/app/pages/authentication/auth-guard/RoleGuard.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, RouterStateSnapshot } from '@angular/router';
+import { AuthService } from 'src/app/services/auth.service';
+
+@Injectable({ providedIn: 'root' })
+export class RoleGuard implements CanActivate {
+  constructor(private authService: AuthService) {}
+
+  canActivate(route: ActivatedRouteSnapshot, _state: RouterStateSnapshot): boolean {
+    const required: string[] = route.data['roles'] ?? [];
+    if (required.length === 0) return true;
+
+    const userRoles = this.authService.getRoles();
+    const allowed = required.some((r) => userRoles.includes(r));
+    if (!allowed) {
+      this.authService.roleBasedRedirect();
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/app/pages/authentication/boxed-login/boxed-login.component.html
+++ b/src/app/pages/authentication/boxed-login/boxed-login.component.html
@@ -21,7 +21,7 @@
 
           <div class="row m-t-24 custom-row">
             <div class="col-12 col-sm-6">
-              <button mat-stroked-button class="w-100">
+              <button mat-stroked-button class="w-100" (click)="loginWithGoogle()">
                 <div class="d-flex align-items-center">
                   <img
                     src="/assets/images/svgs/google-icon.svg"
@@ -34,18 +34,9 @@
               </button>
             </div>
             <div class="col-12 col-sm-6">
-              <button
-                mat-stroked-button
-                class="w-100 d-flex align-items-center"
-              >
+              <button mat-stroked-button class="w-100" (click)="loginWithSSO()">
                 <div class="d-flex align-items-center">
-                  <img
-                    src="/assets/images/svgs/facebook-icon.svg"
-                    alt="facebook"
-                    width="40"
-                    class="m-r-4"
-                  />
-                  Sign in with FB
+                  Sign in with SSO
                 </div>
               </button>
             </div>
@@ -56,11 +47,8 @@
           <form class="m-t-30" [formGroup]="form" (ngSubmit)="submit()">
 
             <mat-label *ngIf="loginSent"
-                       class="mat-subtitle-2 f-s-14 f-w-600 m-b-12 d-block"
-            > {{ loginErrorResponse.message }}
-
-            </mat-label
-            >
+                       class="mat-subtitle-2 f-s-14 f-w-600 m-b-12 d-block text-error"
+            >{{ loginError }}</mat-label>
 
             <mat-label class="mat-subtitle-2 f-s-14 f-w-600 m-b-12 d-block"
             >Username

--- a/src/app/pages/authentication/boxed-login/boxed-login.component.ts
+++ b/src/app/pages/authentication/boxed-login/boxed-login.component.ts
@@ -1,26 +1,38 @@
-import {Component} from '@angular/core';
-import {CoreService} from 'src/app/services/core.service';
-import {FormControl, FormGroup, Validators} from '@angular/forms';
-import {Router} from '@angular/router';
-import { HttpClient } from "@angular/common/http";
-import {environment} from "../../../../../environment";
-import {LoginErrorResponse, LoginResponse} from "./LoginResponse";
-import {MatDialog} from "@angular/material/dialog";
+import { Component, OnInit } from '@angular/core';
+import { CoreService } from 'src/app/services/core.service';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../../../../environment';
+import { LoginErrorResponse, LoginResponse } from './LoginResponse';
+import { MatDialog } from '@angular/material/dialog';
+import { AuthService } from 'src/app/services/auth.service';
 
 
 @Component({
-    selector: 'app-boxed-login',
-    templateUrl: './boxed-login.component.html',
-    standalone: false
+  selector: 'app-boxed-login',
+  templateUrl: './boxed-login.component.html',
+  standalone: false,
 })
-export class AppBoxedLoginComponent {
+export class AppBoxedLoginComponent implements OnInit {
   loginResponse: LoginResponse;
-  loginErrorResponse: LoginErrorResponse;
   options = this.settings.getOptions();
   loginSent: boolean = false;
+  loginError: string = '';
 
-  constructor(private settings: CoreService, private router: Router, private http: HttpClient,
-              public dialog: MatDialog) {
+  constructor(
+    private settings: CoreService,
+    private router: Router,
+    private http: HttpClient,
+    public dialog: MatDialog,
+    private authService: AuthService,
+  ) {}
+
+  ngOnInit(): void {
+    // Redirect already-authenticated users (including those returning from Keycloak)
+    if (this.authService.getToken()) {
+      this.authService.roleBasedRedirect();
+    }
   }
 
   form = new FormGroup({
@@ -33,36 +45,38 @@ export class AppBoxedLoginComponent {
   }
 
   submit() {
-    var payload = {
-      'username': this.form.value.uname,
-      'password': this.form.value.password,
-      'rememberMe': true
+    const payload = {
+      username: this.form.value.uname,
+      password: this.form.value.password,
+      rememberMe: true,
+    };
 
-    }
-// Submit the form
-    this.http.post(environment.apiUrl.concat("authenticate"), payload)
-    .subscribe(
+    this.http.post(environment.apiUrl.concat('authenticate'), payload).subscribe(
       (res: any) => {
         this.loginResponse = res;
-        // User successfully logged in
         if (this.loginResponse.code == 200) {
-          console.log("Successfully fetched user token: ", this.loginResponse);
-          localStorage.setItem('username', <string>payload.username);
+          localStorage.setItem('username', payload.username as string);
           localStorage.setItem('token', this.loginResponse.token);
-          this.router.navigate(['/dashboards/harmony-admin']);
+          this.authService.loadRolesFromToken();
+          this.authService.roleBasedRedirect();
         } else {
           this.loginSent = true;
+          this.loginError = 'Invalid username or password.';
         }
       },
       (error: LoginErrorResponse) => {
-        console.error("An error occurred during login:", error);
+        console.error('Login error:', error);
         this.loginSent = true;
-      }
+        this.loginError = 'Invalid username or password.';
+      },
     );
+  }
 
+  loginWithSSO(): void {
+    this.authService.login();
+  }
 
-    // If correct, navigate to the dashboard, given the authorities in the token
-//    this.router.navigate(['/apps']);
+  loginWithGoogle(): void {
+    this.authService.loginWithGoogle();
   }
 }
-

--- a/src/app/pages/dashboards/dashboards.routing.ts
+++ b/src/app/pages/dashboards/dashboards.routing.ts
@@ -1,4 +1,5 @@
-import {Routes} from '@angular/router';
+import { Routes } from '@angular/router';
+import { RoleGuard } from '../authentication/auth-guard/RoleGuard';
 
 // dashboards
 import {AppDashboard1Component} from './dashboard1/dashboard1.component';
@@ -23,45 +24,41 @@ export const DashboardsRoutes: Routes = [
       {
         path: 'harmony-admin',
         component: HarmonyAdminDashboardComponent,
+        canActivate: [RoleGuard],
         data: {
+          roles: ['ROLE_ADMIN'],
           title: 'Harmony Admin',
-          urls: [
-            {title: 'Admin', url: '/dashboards/harmony-admin'},
-            {title: 'Harmony Admin'},
-          ],
+          urls: [{ title: 'Admin', url: '/dashboards/harmony-admin' }, { title: 'Harmony Admin' }],
         },
       },
       {
         path: 'school-admin',
         component: SchoolAdminDashboardComponent,
+        canActivate: [RoleGuard],
         data: {
+          roles: ['ROLE_ADMIN', 'ROLE_USER'],
           title: 'School Admin',
-          urls: [
-            {title: 'School Admin', url: '/dashboards/school-admin'},
-            {title: 'School Admin'},
-          ],
+          urls: [{ title: 'School Admin', url: '/dashboards/school-admin' }, { title: 'School Admin' }],
         },
       },
       {
         path: 'driver',
         component: DriverDashboardComponent,
+        canActivate: [RoleGuard],
         data: {
+          roles: ['ROLE_ADMIN', 'ROLE_DRIVER'],
           title: 'Driver',
-          urls: [
-            {title: 'Driver', url: '/dashboards/driver'},
-            {title: 'Driver'},
-          ],
+          urls: [{ title: 'Driver', url: '/dashboards/driver' }, { title: 'Driver' }],
         },
       },
       {
         path: 'guardian',
         component: ParentDashboardComponent,
+        canActivate: [RoleGuard],
         data: {
+          roles: ['ROLE_ADMIN', 'ROLE_GUARDIAN'],
           title: 'Guardian',
-          urls: [
-            {title: 'Guardian', url: '/dashboards/guardian'},
-            {title: 'Guardian'},
-          ],
+          urls: [{ title: 'Guardian', url: '/dashboards/guardian' }, { title: 'Guardian' }],
         },
       },
 

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -46,8 +46,14 @@ export class AuthService {
     if (!token) return [];
     try {
       const payload = JSON.parse(atob(token.split('.')[1]));
-      const auth: string = payload['auth'] ?? '';
-      return auth.split(' ').filter((r: string) => r.length > 0);
+      const auth = payload['auth'];
+      const all: string[] = Array.isArray(auth)
+        ? auth
+        : typeof auth === 'string'
+        ? auth.split(' ')
+        : [];
+      // Keep only ROLE_* entries; Keycloak also emits default realm roles
+      return all.filter((r: string) => r.startsWith('ROLE_'));
     } catch {
       return [];
     }

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
+import Keycloak from 'keycloak-js';
+import { NgxPermissionsService } from 'ngx-permissions';
+import { environment } from '../../../environment';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private keycloak: Keycloak = new Keycloak({
+    url: environment.keycloak.url,
+    realm: environment.keycloak.realm,
+    clientId: environment.keycloak.clientId,
+  });
+
+  constructor(private router: Router, private permissionsService: NgxPermissionsService) {}
+
+  async init(): Promise<void> {
+    const authenticated = await this.keycloak.init({ onLoad: 'check-sso', pkceMethod: 'S256' });
+    if (authenticated && this.keycloak.token) {
+      localStorage.setItem('token', this.keycloak.token);
+      this.loadRolesFromToken();
+    }
+  }
+
+  login(): void {
+    this.keycloak.login({ redirectUri: window.location.origin + '/authentication/login' });
+  }
+
+  loginWithGoogle(): void {
+    this.keycloak.login({ idpHint: 'google', redirectUri: window.location.origin + '/authentication/login' });
+  }
+
+  logout(): void {
+    localStorage.removeItem('token');
+    localStorage.removeItem('username');
+    this.permissionsService.flushPermissions();
+    this.keycloak.logout({ redirectUri: window.location.origin + '/authentication/login' });
+  }
+
+  getToken(): string {
+    return localStorage.getItem('token') ?? '';
+  }
+
+  getRoles(): string[] {
+    const token = this.getToken();
+    if (!token) return [];
+    try {
+      const payload = JSON.parse(atob(token.split('.')[1]));
+      const auth: string = payload['auth'] ?? '';
+      return auth.split(' ').filter((r: string) => r.length > 0);
+    } catch {
+      return [];
+    }
+  }
+
+  loadRolesFromToken(): void {
+    this.permissionsService.loadPermissions(this.getRoles());
+  }
+
+  roleBasedRedirect(): void {
+    const roles = this.getRoles();
+    if (roles.includes('ROLE_ADMIN')) {
+      this.router.navigate(['/dashboards/harmony-admin']);
+    } else if (roles.includes('ROLE_USER')) {
+      this.router.navigate(['/dashboards/school-admin']);
+    } else if (roles.includes('ROLE_DRIVER')) {
+      this.router.navigate(['/dashboards/driver']);
+    } else if (roles.includes('ROLE_GUARDIAN')) {
+      this.router.navigate(['/dashboards/guardian']);
+    }
+  }
+}

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -34,7 +34,13 @@ export class AuthService {
     localStorage.removeItem('token');
     localStorage.removeItem('username');
     this.permissionsService.flushPermissions();
-    this.keycloak.logout({ redirectUri: window.location.origin + '/authentication/login' });
+    if (this.keycloak.authenticated) {
+      // Keycloak SSO session active — do a proper OIDC logout.
+      // redirectUri must match an allowed post-logout URI on the Keycloak client.
+      this.keycloak.logout({ redirectUri: window.location.origin + '/' });
+    } else {
+      this.router.navigate(['/authentication/login']);
+    }
   }
 
   getToken(): string {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "sourceMap": true,
     "declaration": false,
     "experimentalDecorators": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "ES2022",
     "module": "ES2022",


### PR DESCRIPTION
## Summary

- **Keycloak SSO** — users can sign in via Keycloak (SSO button) or Google (Google button) alongside the existing credential login flow. Keycloak runs in Podman backed by a local PostgreSQL `keycloak` database.
- **Dual JWT validation** — the Spring Boot API accepts both existing HS512 tokens (from `/api/authenticate`) and RS256 tokens issued by Keycloak, routing by the `iss` claim in a composite `JwtDecoder`.
- **Role-based API security** — per-endpoint `hasAuthority` rules in `SecurityConfiguration` enforce `ROLE_ADMIN`, `ROLE_USER`, `ROLE_GUARDIAN`, and `ROLE_DRIVER` access on all backend routes.
- **Auth interceptor** — a functional Angular HTTP interceptor attaches `Authorization: Bearer <token>` to every outgoing request, replacing manual `HttpHeaders` construction in `CrudActions`, `TerminalViewComponent`, and `StudentTripComponent`.
- **AuthService** — handles Keycloak init (`check-sso`), `login()`, `loginWithGoogle()`, `logout()`, token decoding, `NgxPermissionsService` role loading, and role-based dashboard redirect.
- **RoleGuard** — protects dashboard routes; unauthorized users are redirected to their own dashboard rather than an error page.
- **Sidebar filtering** — `FullComponent` filters nav items at init time so each role only sees the sections they can access.
- **Logout** — properly clears localStorage and Keycloak session (OIDC logout for SSO users, direct navigation for credential users).

## Test plan

- [ ] Credential login: `admin` / `admin` → lands on Harmony Admin dashboard; sidebar shows all items
- [ ] Credential login: `test-guardian` / `admin` → lands on Guardian dashboard; sidebar shows Guardians, Students, Notifications only
- [ ] Credential login: `test-driver` / `admin` → lands on Driver dashboard; sidebar shows Drivers, Vehicles, Trips, Notifications only
- [ ] Direct URL to wrong dashboard (e.g. guardian visiting `/dashboards/harmony-admin`) → redirected to their own dashboard
- [ ] SSO login via Keycloak: click "Sign in with SSO" → Keycloak login → correct role dashboard
- [ ] Google SSO: click "Sign in with Google" → Google consent → lands on Guardian dashboard (ROLE_GUARDIAN assigned by IDP mapper)
- [ ] API calls succeed with 200 for allowed roles; return 403 for forbidden resources
- [ ] Logout from header → localStorage cleared → redirected to login page; Keycloak session invalidated for SSO users

🤖 Generated with [Claude Code](https://claude.com/claude-code)