### PR TITLE
feat: wire all 4 role dashboards to live API

### DIFF
--- a/src/app/pages/dashboards/dashboards.module.ts
+++ b/src/app/pages/dashboards/dashboards.module.ts
@@ -1,9 +1,16 @@
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { DatePipe } from '@angular/common';
-
-// map
-// import { DxVectorMapModule, DxPieChartModule } from 'devextreme-angular';
+import { CommonModule, DatePipe } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule } from '@angular/material/core';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatTableModule } from '@angular/material/table';
+import { MatCardModule } from '@angular/material/card';
 
 import { DashboardsRoutes } from './dashboards.routing';
 import { HarmonyAdminDashboardComponent } from './harmony-admin-dashboard/harmony-admin-dashboard.component';
@@ -15,19 +22,39 @@ import {
   AppPieCardsComponent,
   AppSalesOurVisitorsComponent,
   AppSalesOverviewComponent
-} from "../../components";
+} from '../../components';
 import { AdminCardsComponent } from './harmony-admin-dashboard/admin-cards/admin-cards.component';
 import { AdminTripsGraphComponent } from './harmony-admin-dashboard/admin-trips-graph/admin-trips-graph.component';
 import { StudentActivityGraphComponent } from './harmony-admin-dashboard/student-activity-graph/student-activity-graph.component';
 
 @NgModule({
-  imports: [RouterModule.forChild(DashboardsRoutes), AppPieCardsComponent, AppSalesOurVisitorsComponent, AppSalesOverviewComponent, AppNewsletterCampaignComponent, AdminCardsComponent, AdminTripsGraphComponent, StudentActivityGraphComponent],
+  imports: [
+    RouterModule.forChild(DashboardsRoutes),
+    CommonModule,
+    FormsModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatProgressSpinnerModule,
+    MatProgressBarModule,
+    MatTableModule,
+    MatCardModule,
+    AppPieCardsComponent,
+    AppSalesOurVisitorsComponent,
+    AppSalesOverviewComponent,
+    AppNewsletterCampaignComponent,
+    AdminCardsComponent,
+    AdminTripsGraphComponent,
+    StudentActivityGraphComponent,
+  ],
   providers: [DatePipe],
   declarations: [
     HarmonyAdminDashboardComponent,
     SchoolAdminDashboardComponent,
     DriverDashboardComponent,
-    ParentDashboardComponent
+    ParentDashboardComponent,
   ],
 })
 export class DashboardsModule {}

--- a/src/app/pages/dashboards/driver-dashboard/driver-dashboard.component.html
+++ b/src/app/pages/dashboards/driver-dashboard/driver-dashboard.component.html
@@ -1,16 +1,19 @@
 <mat-card class="m-b-16 cardWithShadow">
   <mat-card-content class="p-16">
     <div class="d-flex align-items-center flex-wrap gap-16">
-      <mat-form-field appearance="outline" class="hide-hint" style="min-width:240px">
-        <mat-label>Date range</mat-label>
-        <mat-date-range-input [rangePicker]="picker">
-          <input matStartDate placeholder="From" [(ngModel)]="range.from" />
-          <input matEndDate placeholder="To" [(ngModel)]="range.to" />
-        </mat-date-range-input>
-        <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
-        <mat-date-range-picker #picker></mat-date-range-picker>
+      <mat-form-field appearance="outline" class="hide-hint" style="width:170px">
+        <mat-label>From</mat-label>
+        <input matInput [matDatepicker]="fromPicker" [(ngModel)]="range.from" />
+        <mat-datepicker-toggle matIconSuffix [for]="fromPicker"></mat-datepicker-toggle>
+        <mat-datepicker #fromPicker></mat-datepicker>
       </mat-form-field>
-      <button mat-flat-button color="primary" (click)="applyRange(range.from, range.to)">Apply</button>
+      <mat-form-field appearance="outline" class="hide-hint" style="width:170px">
+        <mat-label>To</mat-label>
+        <input matInput [matDatepicker]="toPicker" [(ngModel)]="range.to" />
+        <mat-datepicker-toggle matIconSuffix [for]="toPicker"></mat-datepicker-toggle>
+        <mat-datepicker #toPicker></mat-datepicker>
+      </mat-form-field>
+      <button mat-flat-button color="primary" (click)="applyRange()">Apply</button>
       @if (loading) { <mat-spinner diameter="20"></mat-spinner> }
     </div>
   </mat-card-content>

--- a/src/app/pages/dashboards/driver-dashboard/driver-dashboard.component.html
+++ b/src/app/pages/dashboards/driver-dashboard/driver-dashboard.component.html
@@ -1,4 +1,63 @@
-<!--<app-admin-cards [pieChartData]="pieChartData"></app-admin-cards>-->
+<mat-card class="m-b-16 cardWithShadow">
+  <mat-card-content class="p-16">
+    <div class="d-flex align-items-center flex-wrap gap-16">
+      <mat-form-field appearance="outline" class="hide-hint" style="min-width:240px">
+        <mat-label>Date range</mat-label>
+        <mat-date-range-input [rangePicker]="picker">
+          <input matStartDate placeholder="From" [(ngModel)]="range.from" />
+          <input matEndDate placeholder="To" [(ngModel)]="range.to" />
+        </mat-date-range-input>
+        <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
+        <mat-date-range-picker #picker></mat-date-range-picker>
+      </mat-form-field>
+      <button mat-flat-button color="primary" (click)="applyRange(range.from, range.to)">Apply</button>
+      @if (loading) { <mat-spinner diameter="20"></mat-spinner> }
+    </div>
+  </mat-card-content>
+</mat-card>
+
+<app-admin-cards [pieChartData]="pieChartData"></app-admin-cards>
 <app-admin-trips-graph [salesChart]="salesChart" [graphMetadata]="tripGraphMetadata"></app-admin-trips-graph>
-<!--<app-student-activity-graph [newsletterchartOptions]="newsletterchartOptions"-->
-<!--                            [graphMetadata]="graphMetadata"></app-student-activity-graph>-->
+
+@if (currentTripRoster.length > 0) {
+  <mat-card class="m-t-16 cardWithShadow">
+    <mat-card-content class="p-24">
+      <h5 class="f-s-18 f-w-600 m-b-8">Current Trip — Boarding Status</h5>
+      <mat-progress-bar mode="determinate" [value]="boardedPercent" class="m-b-16"></mat-progress-bar>
+      <p class="mat-body-1 m-b-16">{{ boardedPercent }}% boarded</p>
+      <mat-table [dataSource]="currentTripRoster">
+        <ng-container matColumnDef="name">
+          <mat-header-cell *matHeaderCellDef>Student</mat-header-cell>
+          <mat-cell *matCellDef="let row">{{ row.studentName }}</mat-cell>
+        </ng-container>
+        <ng-container matColumnDef="class">
+          <mat-header-cell *matHeaderCellDef>Class</mat-header-cell>
+          <mat-cell *matCellDef="let row">{{ row.classLevel | titlecase }}</mat-cell>
+        </ng-container>
+        <ng-container matColumnDef="status">
+          <mat-header-cell *matHeaderCellDef>Status</mat-header-cell>
+          <mat-cell *matCellDef="let row">
+            <span class="f-w-600"
+              [class.text-primary]="row.boardingStatus === 'BOARDED'"
+              [class.text-warning]="row.boardingStatus === 'PENDING'"
+              [class.text-success]="row.boardingStatus === 'DROPPED_OFF'">
+              {{ row.boardingStatus }}
+            </span>
+          </mat-cell>
+        </ng-container>
+        <ng-container matColumnDef="time">
+          <mat-header-cell *matHeaderCellDef>Pickup Time</mat-header-cell>
+          <mat-cell *matCellDef="let row">{{ row.pickupTime ? (row.pickupTime | date:'HH:mm') : '—' }}</mat-cell>
+        </ng-container>
+        <mat-header-row *matHeaderRowDef="['name','class','status','time']"></mat-header-row>
+        <mat-row *matRowDef="let row; columns: ['name','class','status','time']"></mat-row>
+      </mat-table>
+    </mat-card-content>
+  </mat-card>
+} @else {
+  <mat-card class="m-t-16 cardWithShadow">
+    <mat-card-content class="p-24 text-center">
+      <p class="mat-body-1 text-muted">No active trip at the moment.</p>
+    </mat-card-content>
+  </mat-card>
+}

--- a/src/app/pages/dashboards/driver-dashboard/driver-dashboard.component.ts
+++ b/src/app/pages/dashboards/driver-dashboard/driver-dashboard.component.ts
@@ -1,306 +1,108 @@
-import { Component } from '@angular/core';
-import {piechart} from "../harmony-admin-dashboard/admin-cards/admin-cards.component";
-import {
-  ApexAxisChartSeries,
-  ApexChart,
-  ApexDataLabels, ApexFill, ApexGrid, ApexLegend, ApexMarkers, ApexPlotOptions, ApexStroke,
-  ApexTooltip,
-  ApexXAxis, ApexYAxis
-} from "ng-apexcharts";
-
-export interface newsletterchartOptions {
-  series: ApexAxisChartSeries | any;
-  chart: ApexChart | any;
-  xaxis: ApexXAxis | any;
-  stroke: any | any;
-  tooltip: ApexTooltip | any;
-  dataLabels: ApexDataLabels | any;
-  legend: ApexLegend | any;
-  colors: string[] | any;
-  markers: any;
-  grid: ApexGrid | any;
-  fill: ApexFill | any;
-}
-
-export interface salesChart {
-  series: ApexAxisChartSeries | any;
-  chart: ApexChart | any;
-  dataLabels: ApexDataLabels | any;
-  plotOptions: ApexPlotOptions | any;
-  yaxis: ApexYAxis | any;
-  xaxis: ApexXAxis | any;
-  fill: ApexFill | any;
-  tooltip: ApexTooltip | any;
-  stroke: ApexStroke | any;
-  legend: ApexLegend | any;
-  grid: ApexGrid | any;
-  marker: ApexMarkers | any;
-}
-
+import { Component, OnInit } from '@angular/core';
+import { piechart } from '../harmony-admin-dashboard/admin-cards/admin-cards.component';
+import { DashboardService, DateRange, DriverDashboardData, StudentBoardingItem } from 'src/app/services/dashboard.service';
 
 @Component({
     selector: 'app-driver-dashboard',
     templateUrl: './driver-dashboard.component.html',
     standalone: false
 })
-export class DriverDashboardComponent {
-  // Creating data to feed into the student activity graph
-  public newsletterchartOptions: Partial<newsletterchartOptions> | any = {
-    series: [
-      {
-        name: 'Registered Student',
-        data: [250, 390, 485, 485, 490, 515, 530, 546],
-      },
-      {
-        name: 'Paying Students',
-        data: [245, 360, 478, 480, 480, 500, 530, 530],
-      },
-    ],
-    chart: {
-      height: 365,
-      fontFamily: 'Poppins,sans-serif',
-      type: 'area',
-      foreColor: '#adb0bb',
-    },
-    colors: ['#1e88e5', '#26c6da'],
-    dataLabels: {
-      enabled: false,
-    },
-    markers: {
-      size: 4,
-      border: 1,
-    },
-    legend: {
-      show: false,
-    },
-    xaxis: {
-      categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug'],
-    },
-    grid: {
-      show: true,
-      borderColor: 'rgba(0, 0, 0, .2)',
-      color: 'rgba(0, 0, 0, .2)',
-      strokeDashArray: 2,
-      xaxis: {
-        lines: {
-          show: false,
-        },
-      },
-      yaxis: {
-        lines: {
-          show: true,
-        },
-      },
-    },
-    stroke: {
-      curve: 'smooth',
-      width: 3,
-    },
-    fill: {
-      type: 'gradient',
-      opacity: ['0.1', '0.1'],
-    },
-    tooltip: {
-      theme: 'dark',
-      x: {
-        format: 'dd/MM/yy HH:mm',
-      },
-    },
-  };
-  public graphMetadata: any = {
-    graphTitle: "Students Retaining Rate",
-    graphSubTitle: "Overview of Total Vs Paying Students",
-    lineGraphName1: "Registered Students",
-    lineGraphName2: "Paying Students"
-  }
+export class DriverDashboardComponent implements OnInit {
+  range: DateRange = this.dashboardService.defaultRange();
+  loading = false;
 
-  // Creating data for the school trips graph
-  public salesChart: Partial<salesChart> | any = {
-    series: [
-      {name: 'Trip Count', data: [20, 18, 25, 19, 21, 2, 0]}
-    ],
-    chart: {
-      type: 'bar',
-      height: 320,
-      offsetX: -15,
-      toolbar: {show: false},
-      foreColor: '#adb0bb',
-      fontFamily: 'Poppins',
-      sparkline: {enabled: false},
-    },
-    grid: {
-      show: false,
-    },
-    plotOptions: {
-      bar: {horizontal: false, columnWidth: '35%', borderRadius: 0},
-    },
-    dataLabels: {
-      enabled: false,
-    },
-    xaxis: {
-      type: 'category',
-      categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'July'],
-    },
-    yaxis: {
-      show: true,
-      min: 0,
-      max: 30,
-      tickAmount: 3,
-    },
-    stroke: {
-      show: true,
-      width: 5,
-      lineCap: 'butt',
-      colors: ['transparent'],
-    },
+  fleetPlate = 'N/A';
+  terminalStatus = 'NONE';
+  currentTripRoster: StudentBoardingItem[] = [];
 
-    legend: {
-      show: false,
-    },
-    fill: {
-      colors: ['#26c6da', '#1e88e5'],
-      opacity: 1,
-    },
-    tooltip: {
-      theme: 'dark',
-    },
-  };
+  public salesChart: any = this.buildBarChart([0,0,0,0,0,0,0], ['Mon','Tue','Wed','Thu','Fri','Sat','Sun']);
   public tripGraphMetadata: any = {
-    graphTitle: "Student Trips",
-    graphSubTitle: "Overview of Total Student Trips",
-    barName: "Trips",
+    graphTitle: 'My Trips',
+    graphSubTitle: 'Trips this period',
+    barName: 'Trips',
+  };
+
+  public pieChartData: Partial<piechart>[] = this.buildEmptyCards();
+
+  constructor(private dashboardService: DashboardService) {}
+
+  ngOnInit(): void { this.load(); }
+
+  applyRange(from: Date, to: Date): void {
+    this.range = { from, to };
+    this.load();
   }
 
-  // Creating data for cards
-  public pieChartData: Partial<piechart> | any = [
-    {
-      name: 'Trips',
-      sumOfRecords: 4,
-      series: [3, 1],
-      chart: {
-        type: 'donut',
-        fontFamily: 'Poppins,sans-serif',
-        height: 100,
-        offsetY: 0,
-      },
-      plotOptions: {
-        pie: {
-          donut: {
-            size: '85px',
-          },
-        },
-      },
-      stroke: {
-        width: 0,
-      },
-      legend: {
-        show: false,
-      },
-      tooltip: {
-        fillSeriesColor: false,
-      },
-      dataLabels: {
-        enabled: false,
-      },
-      labels: ['Active', 'Inactive'],
-      colors: ['#1e88e5', 'rgba(0, 0, 0, 0.1)'],
-    },
-    {
-      name: 'Cars',
-      sumOfRecords: 4,
-      series: [4, 0],
-      chart: {
-        type: 'donut',
-        fontFamily: 'Poppins,sans-serif',
-        height: 100,
-        offsetY: 0,
-      },
-      plotOptions: {
-        pie: {
-          donut: {
-            size: '85px',
-          },
-        },
-      },
-      stroke: {
-        width: 0,
-      },
-      legend: {
-        show: false,
-      },
-      tooltip: {
-        fillSeriesColor: false,
-      },
-      dataLabels: {
-        enabled: false,
-      },
-      labels: ['Online', 'Offline'],
-      colors: ['#26c6da', 'rgba(0, 0, 0, 0.1)'],
-    },
-    {
-      name: 'Students',
-      sumOfRecords: 546,
-      series: [516, 30],
-      chart: {
-        type: 'donut',
-        fontFamily: 'Poppins,sans-serif',
-        height: 100,
-        offsetY: 0,
-      },
-      plotOptions: {
-        pie: {
-          donut: {
-            size: '85px',
-          },
-        },
-      },
-      stroke: {
-        width: 0,
-      },
-      legend: {
-        show: false,
-      },
-      tooltip: {
-        fillSeriesColor: false,
-      },
-      dataLabels: {
-        enabled: false,
-      },
-      labels: ['Active', 'Inactive'],
-      colors: ['#ffb22b', 'rgba(0, 0, 0, 0.1)'],
-    },
-    {
-      name: 'Invoices',
-      sumOfRecords: 2,
-      series: [2, 0],
-      chart: {
-        type: 'donut',
-        fontFamily: 'Poppins,sans-serif',
-        height: 100,
-        offsetY: 0,
-      },
-      plotOptions: {
-        pie: {
-          donut: {
-            size: '85px',
-          },
-        },
-      },
-      stroke: {
-        width: 0,
-      },
-      legend: {
-        show: false,
-      },
-      tooltip: {
-        fillSeriesColor: false,
-      },
-      dataLabels: {
-        enabled: false,
-      },
-      labels: ['Paid', 'Unpaid'],
-      colors: ['#fc4b6c', 'rgba(0, 0, 0, 0.1)'],
-    }
-  ];
+  get boardedPercent(): number {
+    const total = this.currentTripRoster.length;
+    if (!total) return 0;
+    const boarded = this.currentTripRoster.filter(s => s.boardingStatus === 'BOARDED' || s.boardingStatus === 'DROPPED_OFF').length;
+    return Math.round((boarded / total) * 100);
+  }
 
+  private load(): void {
+    this.loading = true;
+    this.dashboardService.getDriverDashboard(this.range).subscribe({
+      next: data => { this.apply(data); this.loading = false; },
+      error: () => { this.loading = false; },
+    });
+  }
+
+  private apply(data: DriverDashboardData): void {
+    this.fleetPlate = data.fleetNumberPlate || 'N/A';
+    this.terminalStatus = data.terminalStatus || 'NONE';
+    this.currentTripRoster = data.currentTripRoster ?? [];
+
+    const boarded = data.boardedInRange ?? 0;
+    const pending = data.pendingInRange ?? 0;
+    const total = data.totalStudentsOnFleet ?? 0;
+    const completed = data.tripsCompletedInRange ?? 0;
+    const tripsTotal = data.tripsTotalInRange ?? 0;
+
+    this.pieChartData = [
+      this.donut('Students Boarded', boarded + pending, [boarded, pending], ['Boarded', 'Pending'], '#1e88e5'),
+      this.donut('My Bus', 1, [1, 0], [this.fleetPlate, ''], this.terminalStatus === 'ONLINE' ? '#26c6da' : '#fc4b6c'),
+      this.donut('Trips', tripsTotal, [completed, tripsTotal - completed], ['Completed', 'Pending'], '#ffb22b'),
+      this.donut('Students', total, [boarded, total - boarded], ['Boarded', 'Not Boarded'], '#fc4b6c'),
+    ];
+
+    this.salesChart = this.buildBarChart(data.dailyTripCounts ?? [], data.dailyTripLabels ?? []);
+  }
+
+  private donut(name: string, total: number, series: number[], labels: string[], color: string): Partial<piechart> {
+    return {
+      name, sumOfRecords: total, series, labels,
+      chart: { type: 'donut', fontFamily: 'Poppins,sans-serif', height: 100, offsetY: 0 },
+      plotOptions: { pie: { donut: { size: '85px' } } },
+      stroke: { width: 0 }, legend: { show: false },
+      tooltip: { fillSeriesColor: false }, dataLabels: { enabled: false },
+      colors: [color, 'rgba(0,0,0,0.1)'],
+    };
+  }
+
+  private buildBarChart(data: number[], labels: string[]): any {
+    const max = data.length ? Math.max(...data, 5) + 5 : 10;
+    return {
+      series: [{ name: 'Trip Count', data }],
+      chart: { type: 'bar', height: 320, offsetX: -15, toolbar: { show: false }, foreColor: '#adb0bb', fontFamily: 'Poppins', sparkline: { enabled: false } },
+      grid: { show: false },
+      plotOptions: { bar: { horizontal: false, columnWidth: '35%', borderRadius: 0 } },
+      dataLabels: { enabled: false },
+      xaxis: { type: 'category', categories: labels },
+      yaxis: { show: true, min: 0, max, tickAmount: 3 },
+      stroke: { show: true, width: 5, lineCap: 'butt', colors: ['transparent'] },
+      legend: { show: false },
+      fill: { colors: ['#26c6da', '#1e88e5'], opacity: 1 },
+      tooltip: { theme: 'dark' },
+    };
+  }
+
+  private buildEmptyCards(): Partial<piechart>[] {
+    return [
+      this.donut('Students Boarded', 0, [0, 0], ['Boarded',   'Pending'],     '#1e88e5'),
+      this.donut('My Bus',           0, [0, 0], ['N/A',       ''],            '#26c6da'),
+      this.donut('Trips',            0, [0, 0], ['Completed', 'Pending'],     '#ffb22b'),
+      this.donut('Students',         0, [0, 0], ['Boarded',   'Not Boarded'], '#fc4b6c'),
+    ];
+  }
 }

--- a/src/app/pages/dashboards/driver-dashboard/driver-dashboard.component.ts
+++ b/src/app/pages/dashboards/driver-dashboard/driver-dashboard.component.ts
@@ -28,8 +28,7 @@ export class DriverDashboardComponent implements OnInit {
 
   ngOnInit(): void { this.load(); }
 
-  applyRange(from: Date, to: Date): void {
-    this.range = { from, to };
+  applyRange(): void {
     this.load();
   }
 

--- a/src/app/pages/dashboards/harmony-admin-dashboard/harmony-admin-dashboard.component.html
+++ b/src/app/pages/dashboards/harmony-admin-dashboard/harmony-admin-dashboard.component.html
@@ -1,16 +1,19 @@
 <mat-card class="m-b-16 cardWithShadow">
   <mat-card-content class="p-16">
     <div class="d-flex align-items-center flex-wrap gap-16">
-      <mat-form-field appearance="outline" class="hide-hint" style="min-width:240px">
-        <mat-label>Date range</mat-label>
-        <mat-date-range-input [rangePicker]="picker">
-          <input matStartDate placeholder="From" [(ngModel)]="range.from" />
-          <input matEndDate placeholder="To" [(ngModel)]="range.to" />
-        </mat-date-range-input>
-        <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
-        <mat-date-range-picker #picker></mat-date-range-picker>
+      <mat-form-field appearance="outline" class="hide-hint" style="width:170px">
+        <mat-label>From</mat-label>
+        <input matInput [matDatepicker]="fromPicker" [(ngModel)]="range.from" />
+        <mat-datepicker-toggle matIconSuffix [for]="fromPicker"></mat-datepicker-toggle>
+        <mat-datepicker #fromPicker></mat-datepicker>
       </mat-form-field>
-      <button mat-flat-button color="primary" (click)="applyRange(range.from, range.to)">Apply</button>
+      <mat-form-field appearance="outline" class="hide-hint" style="width:170px">
+        <mat-label>To</mat-label>
+        <input matInput [matDatepicker]="toPicker" [(ngModel)]="range.to" />
+        <mat-datepicker-toggle matIconSuffix [for]="toPicker"></mat-datepicker-toggle>
+        <mat-datepicker #toPicker></mat-datepicker>
+      </mat-form-field>
+      <button mat-flat-button color="primary" (click)="applyRange()">Apply</button>
       @if (loading) { <mat-spinner diameter="20"></mat-spinner> }
     </div>
   </mat-card-content>

--- a/src/app/pages/dashboards/harmony-admin-dashboard/harmony-admin-dashboard.component.html
+++ b/src/app/pages/dashboards/harmony-admin-dashboard/harmony-admin-dashboard.component.html
@@ -1,4 +1,21 @@
+<mat-card class="m-b-16 cardWithShadow">
+  <mat-card-content class="p-16">
+    <div class="d-flex align-items-center flex-wrap gap-16">
+      <mat-form-field appearance="outline" class="hide-hint" style="min-width:240px">
+        <mat-label>Date range</mat-label>
+        <mat-date-range-input [rangePicker]="picker">
+          <input matStartDate placeholder="From" [(ngModel)]="range.from" />
+          <input matEndDate placeholder="To" [(ngModel)]="range.to" />
+        </mat-date-range-input>
+        <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
+        <mat-date-range-picker #picker></mat-date-range-picker>
+      </mat-form-field>
+      <button mat-flat-button color="primary" (click)="applyRange(range.from, range.to)">Apply</button>
+      @if (loading) { <mat-spinner diameter="20"></mat-spinner> }
+    </div>
+  </mat-card-content>
+</mat-card>
+
 <app-admin-cards [pieChartData]="pieChartData"></app-admin-cards>
 <app-admin-trips-graph [salesChart]="salesChart" [graphMetadata]="tripGraphMetadata"></app-admin-trips-graph>
-<app-student-activity-graph [newsletterchartOptions]="newsletterchartOptions"
-[graphMetadata]="graphMetadata"></app-student-activity-graph>
+<app-student-activity-graph [newsletterchartOptions]="newsletterchartOptions" [graphMetadata]="graphMetadata"></app-student-activity-graph>

--- a/src/app/pages/dashboards/harmony-admin-dashboard/harmony-admin-dashboard.component.ts
+++ b/src/app/pages/dashboards/harmony-admin-dashboard/harmony-admin-dashboard.component.ts
@@ -1,312 +1,127 @@
-import {Component} from '@angular/core';
-import {
-  ApexAxisChartSeries,
-  ApexChart,
-  ApexDataLabels,
-  ApexFill,
-  ApexGrid,
-  ApexLegend,
-  ApexMarkers,
-  ApexPlotOptions,
-  ApexStroke,
-  ApexTooltip,
-  ApexXAxis,
-  ApexYAxis
-} from "ng-apexcharts";
-import {piechart} from "./admin-cards/admin-cards.component";
-
-export interface newsletterchartOptions {
-  series: ApexAxisChartSeries | any;
-  chart: ApexChart | any;
-  xaxis: ApexXAxis | any;
-  stroke: any | any;
-  tooltip: ApexTooltip | any;
-  dataLabels: ApexDataLabels | any;
-  legend: ApexLegend | any;
-  colors: string[] | any;
-  markers: any;
-  grid: ApexGrid | any;
-  fill: ApexFill | any;
-}
-
-export interface salesChart {
-  series: ApexAxisChartSeries | any;
-  chart: ApexChart | any;
-  dataLabels: ApexDataLabels | any;
-  plotOptions: ApexPlotOptions | any;
-  yaxis: ApexYAxis | any;
-  xaxis: ApexXAxis | any;
-  fill: ApexFill | any;
-  tooltip: ApexTooltip | any;
-  stroke: ApexStroke | any;
-  legend: ApexLegend | any;
-  grid: ApexGrid | any;
-  marker: ApexMarkers | any;
-}
-
+import { Component, OnInit } from '@angular/core';
+import { piechart } from './admin-cards/admin-cards.component';
+import { AdminDashboardData, DateRange, DashboardService } from 'src/app/services/dashboard.service';
 
 @Component({
     selector: 'app-harmony-admin-dashboard',
     templateUrl: './harmony-admin-dashboard.component.html',
     standalone: false
 })
-export class HarmonyAdminDashboardComponent {
-  // Creating data to feed into the student activity graph
-  public newsletterchartOptions: Partial<newsletterchartOptions> | any = {
-    series: [
-      {
-        name: 'Registered Student',
-        data: [50, 100, 250, 500, 750, 1000, 1100, 1300],
-      },
-      {
-        name: 'Paying Students',
-        data: [50, 90, 200, 475, 730, 800, 1050, 1200],
-      },
-    ],
-    chart: {
-      height: 365,
-      fontFamily: 'Poppins,sans-serif',
-      type: 'area',
-      foreColor: '#adb0bb',
-    },
-    colors: ['#1e88e5', '#26c6da'],
-    dataLabels: {
-      enabled: false,
-    },
-    markers: {
-      size: 4,
-      border: 1,
-    },
-    legend: {
-      show: false,
-    },
-    xaxis: {
-      categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug'],
-    },
-    grid: {
-      show: true,
-      borderColor: 'rgba(0, 0, 0, .2)',
-      color: 'rgba(0, 0, 0, .2)',
-      strokeDashArray: 2,
-      xaxis: {
-        lines: {
-          show: false,
-        },
-      },
-      yaxis: {
-        lines: {
-          show: true,
-        },
-      },
-    },
-    stroke: {
-      curve: 'smooth',
-      width: 3,
-    },
-    fill: {
-      type: 'gradient',
-      opacity: ['0.1', '0.1'],
-    },
-    tooltip: {
-      theme: 'dark',
-      x: {
-        format: 'dd/MM/yy HH:mm',
-      },
-    },
-  };
+export class HarmonyAdminDashboardComponent implements OnInit {
+  range: DateRange = this.dashboardService.defaultRange();
+  loading = false;
+
+  public newsletterchartOptions: any = this.buildAreaChart(
+    [0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0],
+    ['Jan','Feb','Mar','Apr','May','Jun']
+  );
   public graphMetadata: any = {
-    graphTitle: "Students Retaining Rate",
-    graphSubTitle: "Overview of Total Vs Paying Students",
-    lineGraphName1: "Registered Students",
-    lineGraphName2: "Paying Students"
-  }
-
-  // Creating data for the school trips graph
-  public salesChart: Partial<salesChart> | any = {
-    series: [
-      {name: 'Trip Count', data: [20, 18, 25, 19, 21, 2, 0]}
-    ],
-    chart: {
-      type: 'bar',
-      height: 320,
-      offsetX: -15,
-      toolbar: {show: false},
-      foreColor: '#adb0bb',
-      fontFamily: 'Poppins',
-      sparkline: {enabled: false},
-    },
-    grid: {
-      show: false,
-    },
-    plotOptions: {
-      bar: {horizontal: false, columnWidth: '35%', borderRadius: 0},
-    },
-    dataLabels: {
-      enabled: false,
-    },
-    xaxis: {
-      type: 'category',
-      categories: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
-    },
-    yaxis: {
-      show: true,
-      min: 0,
-      max: 30,
-      tickAmount: 3,
-    },
-    stroke: {
-      show: true,
-      width: 5,
-      lineCap: 'butt',
-      colors: ['transparent'],
-    },
-
-    legend: {
-      show: false,
-    },
-    fill: {
-      colors: ['#26c6da', '#1e88e5'],
-      opacity: 1,
-    },
-    tooltip: {
-      theme: 'dark',
-    },
+    graphTitle: 'Students Retaining Rate',
+    graphSubTitle: 'Overview of Total Vs Paying Students',
+    lineGraphName1: 'Registered Students',
+    lineGraphName2: 'Paying Students',
   };
+
+  public salesChart: any = this.buildBarChart([0,0,0,0,0,0,0], ['Mon','Tue','Wed','Thu','Fri','Sat','Sun']);
   public tripGraphMetadata: any = {
-    graphTitle: "Student Trips",
-    graphSubTitle: "Overview of Total Student Trips",
-    barName: "Trips",
+    graphTitle: 'Student Trips',
+    graphSubTitle: 'Overview of Total Student Trips',
+    barName: 'Trips',
+  };
+
+  public pieChartData: Partial<piechart>[] = this.buildEmptyCards();
+
+  constructor(private dashboardService: DashboardService) {}
+
+  ngOnInit(): void {
+    this.load();
   }
 
-  // Creating data for cards
-  public pieChartData: Partial<piechart> | any = [
-    {
-      name: 'Schools',
-      sumOfRecords: 10,
-      series: [9, 1],
-      chart: {
-        type: 'donut',
-        fontFamily: 'Poppins,sans-serif',
-        height: 100,
-        offsetY: 0,
-      },
-      plotOptions: {
-        pie: {
-          donut: {
-            size: '85px',
-          },
-        },
-      },
-      stroke: {
-        width: 0,
-      },
-      legend: {
-        show: false,
-      },
-      tooltip: {
-        fillSeriesColor: false,
-      },
-      dataLabels: {
-        enabled: false,
-      },
-      labels: ['Active', 'Inactive'],
-      colors: ['#1e88e5', 'rgba(0, 0, 0, 0.1)'],
-    },
-    {
-      name: 'Terminals',
-      sumOfRecords: 22,
-      series: [10, 2],
-      chart: {
-        type: 'donut',
-        fontFamily: 'Poppins,sans-serif',
-        height: 100,
-        offsetY: 0,
-      },
-      plotOptions: {
-        pie: {
-          donut: {
-            size: '85px',
-          },
-        },
-      },
-      stroke: {
-        width: 0,
-      },
-      legend: {
-        show: false,
-      },
-      tooltip: {
-        fillSeriesColor: false,
-      },
-      dataLabels: {
-        enabled: false,
-      },
-      labels: ['Online', 'Offline'],
-      colors: ['#26c6da', 'rgba(0, 0, 0, 0.1)'],
-    },
-    {
-      name: 'Students',
-      sumOfRecords: 2500,
-      series: [2000, 500],
-      chart: {
-        type: 'donut',
-        fontFamily: 'Poppins,sans-serif',
-        height: 100,
-        offsetY: 0,
-      },
-      plotOptions: {
-        pie: {
-          donut: {
-            size: '85px',
-          },
-        },
-      },
-      stroke: {
-        width: 0,
-      },
-      legend: {
-        show: false,
-      },
-      tooltip: {
-        fillSeriesColor: false,
-      },
-      dataLabels: {
-        enabled: false,
-      },
-      labels: ['Active', 'Inactive'],
-      colors: ['#ffb22b', 'rgba(0, 0, 0, 0.1)'],
-    },
-    {
-      name: 'Invoices',
-      sumOfRecords: 8,
-      series: [6, 2],
-      chart: {
-        type: 'donut',
-        fontFamily: 'Poppins,sans-serif',
-        height: 100,
-        offsetY: 0,
-      },
-      plotOptions: {
-        pie: {
-          donut: {
-            size: '85px',
-          },
-        },
-      },
-      stroke: {
-        width: 0,
-      },
-      legend: {
-        show: false,
-      },
-      tooltip: {
-        fillSeriesColor: false,
-      },
-      dataLabels: {
-        enabled: false,
-      },
-      labels: ['Paid', 'Unpaid'],
-      colors: ['#fc4b6c', 'rgba(0, 0, 0, 0.1)'],
-    }
-  ];
+  applyRange(from: Date, to: Date): void {
+    this.range = { from, to };
+    this.load();
+  }
+
+  private load(): void {
+    this.loading = true;
+    this.dashboardService.getAdminDashboard(this.range).subscribe({
+      next: data => { this.apply(data); this.loading = false; },
+      error: () => { this.loading = false; },
+    });
+  }
+
+  private apply(data: AdminDashboardData): void {
+    this.pieChartData = [
+      this.donut('Schools',    data.totalSchools,   [data.activeSchools,   data.inactiveSchools],  ['Active','Inactive'], '#1e88e5'),
+      this.donut('Terminals',  data.totalTerminals,  [data.onlineTerminals, data.offlineTerminals], ['Online','Offline'],  '#26c6da'),
+      this.donut('Students',   data.totalStudents,   [data.activeStudents,  data.inactiveStudents], ['Active','Inactive'], '#ffb22b'),
+      this.donut('Drivers',    data.totalDrivers,    [data.activeDrivers,   data.totalDrivers - data.activeDrivers], ['Active','Inactive'], '#fc4b6c'),
+    ];
+
+    this.salesChart = this.buildBarChart(data.dailyTripCounts ?? [], data.dailyTripLabels ?? []);
+    this.newsletterchartOptions = this.buildAreaChart(
+      data.monthlyStudentTotals ?? [],
+      data.monthlyPayingStudents ?? [],
+      data.monthlyLabels ?? []
+    );
+  }
+
+  private donut(name: string, total: number, series: number[], labels: string[], color: string): Partial<piechart> {
+    return {
+      name, sumOfRecords: total, series, labels,
+      chart: { type: 'donut', fontFamily: 'Poppins,sans-serif', height: 100, offsetY: 0 },
+      plotOptions: { pie: { donut: { size: '85px' } } },
+      stroke: { width: 0 },
+      legend: { show: false },
+      tooltip: { fillSeriesColor: false },
+      dataLabels: { enabled: false },
+      colors: [color, 'rgba(0,0,0,0.1)'],
+    };
+  }
+
+  private buildBarChart(data: number[], labels: string[]): any {
+    const max = data.length ? Math.max(...data, 5) + 5 : 30;
+    return {
+      series: [{ name: 'Trip Count', data }],
+      chart: { type: 'bar', height: 320, offsetX: -15, toolbar: { show: false }, foreColor: '#adb0bb', fontFamily: 'Poppins', sparkline: { enabled: false } },
+      grid: { show: false },
+      plotOptions: { bar: { horizontal: false, columnWidth: '35%', borderRadius: 0 } },
+      dataLabels: { enabled: false },
+      xaxis: { type: 'category', categories: labels },
+      yaxis: { show: true, min: 0, max, tickAmount: 3 },
+      stroke: { show: true, width: 5, lineCap: 'butt', colors: ['transparent'] },
+      legend: { show: false },
+      fill: { colors: ['#26c6da', '#1e88e5'], opacity: 1 },
+      tooltip: { theme: 'dark' },
+    };
+  }
+
+  private buildAreaChart(registered: number[], paying: number[], labels: string[]): any {
+    return {
+      series: [
+        { name: 'Registered Students', data: registered },
+        { name: 'Paying Students', data: paying },
+      ],
+      chart: { height: 365, fontFamily: 'Poppins,sans-serif', type: 'area', foreColor: '#adb0bb' },
+      colors: ['#1e88e5', '#26c6da'],
+      dataLabels: { enabled: false },
+      markers: { size: 4, border: 1 },
+      legend: { show: false },
+      xaxis: { categories: labels },
+      grid: { show: true, borderColor: 'rgba(0,0,0,.2)', strokeDashArray: 2, xaxis: { lines: { show: false } }, yaxis: { lines: { show: true } } },
+      stroke: { curve: 'smooth', width: 3 },
+      fill: { type: 'gradient', opacity: ['0.1', '0.1'] },
+      tooltip: { theme: 'dark' },
+    };
+  }
+
+  private buildEmptyCards(): Partial<piechart>[] {
+    return [
+      this.donut('Schools', 0, [0, 0], ['Active', 'Inactive'], '#1e88e5'),
+      this.donut('Terminals', 0, [0, 0], ['Online', 'Offline'], '#26c6da'),
+      this.donut('Students', 0, [0, 0], ['Active', 'Inactive'], '#ffb22b'),
+      this.donut('Drivers', 0, [0, 0], ['Active', 'Inactive'], '#fc4b6c'),
+    ];
+  }
 }

--- a/src/app/pages/dashboards/harmony-admin-dashboard/harmony-admin-dashboard.component.ts
+++ b/src/app/pages/dashboards/harmony-admin-dashboard/harmony-admin-dashboard.component.ts
@@ -38,8 +38,7 @@ export class HarmonyAdminDashboardComponent implements OnInit {
     this.load();
   }
 
-  applyRange(from: Date, to: Date): void {
-    this.range = { from, to };
+  applyRange(): void {
     this.load();
   }
 

--- a/src/app/pages/dashboards/parent-dashboard/parent-dashboard.component.html
+++ b/src/app/pages/dashboards/parent-dashboard/parent-dashboard.component.html
@@ -1,4 +1,58 @@
+<mat-card class="m-b-16 cardWithShadow">
+  <mat-card-content class="p-16">
+    <div class="d-flex align-items-center flex-wrap gap-16">
+      <mat-form-field appearance="outline" class="hide-hint" style="min-width:240px">
+        <mat-label>Date range</mat-label>
+        <mat-date-range-input [rangePicker]="picker">
+          <input matStartDate placeholder="From" [(ngModel)]="range.from" />
+          <input matEndDate placeholder="To" [(ngModel)]="range.to" />
+        </mat-date-range-input>
+        <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
+        <mat-date-range-picker #picker></mat-date-range-picker>
+      </mat-form-field>
+      <button mat-flat-button color="primary" (click)="applyRange(range.from, range.to)">Apply</button>
+      @if (loading) { <mat-spinner diameter="20"></mat-spinner> }
+    </div>
+  </mat-card-content>
+</mat-card>
+
 <app-admin-cards [pieChartData]="pieChartData"></app-admin-cards>
 <app-admin-trips-graph [salesChart]="salesChart" [graphMetadata]="tripGraphMetadata"></app-admin-trips-graph>
-<!--<app-student-activity-graph [newsletterchartOptions]="newsletterchartOptions"-->
-<!--                            [graphMetadata]="graphMetadata"></app-student-activity-graph>-->
+
+@if (childrenStatus.length > 0) {
+  <div class="row m-t-16">
+    @for (child of childrenStatus; track child.id) {
+      <div class="col-lg-4 col-md-6">
+        <mat-card class="cardWithShadow m-b-16">
+          <mat-card-content class="p-16">
+            <h6 class="f-w-600 f-s-16 m-b-4">{{ child.name }}</h6>
+            <p class="mat-body-2 text-muted m-b-8">{{ child.classLevel | titlecase }} &middot; Bus: {{ child.fleetNumberPlate }}</p>
+            <div class="d-flex gap-8 flex-wrap">
+              <span class="badge"
+                [class.bg-primary]="child.boardingStatus === 'BOARDED'"
+                [class.bg-warning]="child.boardingStatus === 'PENDING'"
+                [class.bg-success]="child.boardingStatus === 'DROPPED_OFF'"
+                [class.bg-secondary]="child.boardingStatus === 'NONE'">
+                {{ child.boardingStatus }}
+              </span>
+              <span class="badge"
+                [class.bg-success]="child.billingStatus === 'ACTIVE'"
+                [class.bg-danger]="child.billingStatus === 'OVERDUE'">
+                {{ child.billingStatus === 'ACTIVE' ? 'Paid' : 'Overdue' }}
+              </span>
+            </div>
+            @if (child.lastTripDate) {
+              <p class="mat-caption text-muted m-t-8 m-b-0">Last trip: {{ child.lastTripDate | date:'dd MMM, HH:mm' }}</p>
+            }
+          </mat-card-content>
+        </mat-card>
+      </div>
+    }
+  </div>
+} @else {
+  <mat-card class="m-t-16 cardWithShadow">
+    <mat-card-content class="p-24 text-center">
+      <p class="mat-body-1 text-muted">No children linked to your account.</p>
+    </mat-card-content>
+  </mat-card>
+}

--- a/src/app/pages/dashboards/parent-dashboard/parent-dashboard.component.html
+++ b/src/app/pages/dashboards/parent-dashboard/parent-dashboard.component.html
@@ -1,16 +1,19 @@
 <mat-card class="m-b-16 cardWithShadow">
   <mat-card-content class="p-16">
     <div class="d-flex align-items-center flex-wrap gap-16">
-      <mat-form-field appearance="outline" class="hide-hint" style="min-width:240px">
-        <mat-label>Date range</mat-label>
-        <mat-date-range-input [rangePicker]="picker">
-          <input matStartDate placeholder="From" [(ngModel)]="range.from" />
-          <input matEndDate placeholder="To" [(ngModel)]="range.to" />
-        </mat-date-range-input>
-        <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
-        <mat-date-range-picker #picker></mat-date-range-picker>
+      <mat-form-field appearance="outline" class="hide-hint" style="width:170px">
+        <mat-label>From</mat-label>
+        <input matInput [matDatepicker]="fromPicker" [(ngModel)]="range.from" />
+        <mat-datepicker-toggle matIconSuffix [for]="fromPicker"></mat-datepicker-toggle>
+        <mat-datepicker #fromPicker></mat-datepicker>
       </mat-form-field>
-      <button mat-flat-button color="primary" (click)="applyRange(range.from, range.to)">Apply</button>
+      <mat-form-field appearance="outline" class="hide-hint" style="width:170px">
+        <mat-label>To</mat-label>
+        <input matInput [matDatepicker]="toPicker" [(ngModel)]="range.to" />
+        <mat-datepicker-toggle matIconSuffix [for]="toPicker"></mat-datepicker-toggle>
+        <mat-datepicker #toPicker></mat-datepicker>
+      </mat-form-field>
+      <button mat-flat-button color="primary" (click)="applyRange()">Apply</button>
       @if (loading) { <mat-spinner diameter="20"></mat-spinner> }
     </div>
   </mat-card-content>

--- a/src/app/pages/dashboards/parent-dashboard/parent-dashboard.component.ts
+++ b/src/app/pages/dashboards/parent-dashboard/parent-dashboard.component.ts
@@ -1,314 +1,91 @@
-import {Component} from '@angular/core';
-import {
-  ApexAxisChartSeries,
-  ApexChart,
-  ApexDataLabels,
-  ApexFill,
-  ApexGrid,
-  ApexLegend,
-  ApexMarkers,
-  ApexPlotOptions,
-  ApexStroke,
-  ApexTooltip,
-  ApexXAxis,
-  ApexYAxis
-} from "ng-apexcharts";
-import {piechart} from "../harmony-admin-dashboard/admin-cards/admin-cards.component";
-
-
-export interface newsletterchartOptions {
-  series: ApexAxisChartSeries | any;
-  chart: ApexChart | any;
-  xaxis: ApexXAxis | any;
-  stroke: any | any;
-  tooltip: ApexTooltip | any;
-  dataLabels: ApexDataLabels | any;
-  legend: ApexLegend | any;
-  colors: string[] | any;
-  markers: any;
-  grid: ApexGrid | any;
-  fill: ApexFill | any;
-}
-
-export interface salesChart {
-  series: ApexAxisChartSeries | any;
-  chart: ApexChart | any;
-  dataLabels: ApexDataLabels | any;
-  plotOptions: ApexPlotOptions | any;
-  yaxis: ApexYAxis | any;
-  xaxis: ApexXAxis | any;
-  fill: ApexFill | any;
-  tooltip: ApexTooltip | any;
-  stroke: ApexStroke | any;
-  legend: ApexLegend | any;
-  grid: ApexGrid | any;
-  marker: ApexMarkers | any;
-}
+import { Component, OnInit } from '@angular/core';
+import { piechart } from '../harmony-admin-dashboard/admin-cards/admin-cards.component';
+import { ChildStatus, DashboardService, DateRange, GuardianDashboardData } from 'src/app/services/dashboard.service';
 
 @Component({
     selector: 'app-parent-dashboard',
     templateUrl: './parent-dashboard.component.html',
     standalone: false
 })
-export class ParentDashboardComponent {
-  // Creating data to feed into the student activity graph
-  public newsletterchartOptions: Partial<newsletterchartOptions> | any = {
-    series: [
-      {
-        name: 'Registered Student',
-        data: [250, 390, 485, 485, 490, 515, 530, 546],
-      },
-      {
-        name: 'Paying Students',
-        data: [245, 360, 478, 480, 480, 500, 530, 530],
-      },
-    ],
-    chart: {
-      height: 365,
-      fontFamily: 'Poppins,sans-serif',
-      type: 'area',
-      foreColor: '#adb0bb',
-    },
-    colors: ['#1e88e5', '#26c6da'],
-    dataLabels: {
-      enabled: false,
-    },
-    markers: {
-      size: 4,
-      border: 1,
-    },
-    legend: {
-      show: false,
-    },
-    xaxis: {
-      categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug'],
-    },
-    grid: {
-      show: true,
-      borderColor: 'rgba(0, 0, 0, .2)',
-      color: 'rgba(0, 0, 0, .2)',
-      strokeDashArray: 2,
-      xaxis: {
-        lines: {
-          show: false,
-        },
-      },
-      yaxis: {
-        lines: {
-          show: true,
-        },
-      },
-    },
-    stroke: {
-      curve: 'smooth',
-      width: 3,
-    },
-    fill: {
-      type: 'gradient',
-      opacity: ['0.1', '0.1'],
-    },
-    tooltip: {
-      theme: 'dark',
-      x: {
-        format: 'dd/MM/yy HH:mm',
-      },
-    },
-  };
-  public graphMetadata: any = {
-    graphTitle: "Students Retaining Rate",
-    graphSubTitle: "Overview of Total Vs Paying Students",
-    lineGraphName1: "Registered Students",
-    lineGraphName2: "Paying Students"
-  }
+export class ParentDashboardComponent implements OnInit {
+  range: DateRange = this.dashboardService.defaultRange();
+  loading = false;
 
+  childrenStatus: ChildStatus[] = [];
 
-  // Creating data for the school trips graph
-  public salesChart: Partial<salesChart> | any = {
-    series: [
-      {name: 'Trip Count', data: [20, 18, 25, 19, 21, 2, 0]}
-    ],
-    chart: {
-      type: 'bar',
-      height: 320,
-      offsetX: -15,
-      toolbar: {show: false},
-      foreColor: '#adb0bb',
-      fontFamily: 'Poppins',
-      sparkline: {enabled: false},
-    },
-    grid: {
-      show: false,
-    },
-    plotOptions: {
-      bar: {horizontal: false, columnWidth: '35%', borderRadius: 0},
-    },
-    dataLabels: {
-      enabled: false,
-    },
-    xaxis: {
-      type: 'category',
-      categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul'],
-    },
-    yaxis: {
-      show: true,
-      min: 0,
-      max: 30,
-      tickAmount: 3,
-    },
-    stroke: {
-      show: true,
-      width: 5,
-      lineCap: 'butt',
-      colors: ['transparent'],
-    },
-
-    legend: {
-      show: false,
-    },
-    fill: {
-      colors: ['#26c6da', '#1e88e5'],
-      opacity: 1,
-    },
-    tooltip: {
-      theme: 'dark',
-    },
-  };
+  public salesChart: any = this.buildBarChart([0,0,0,0,0,0,0], ['Mon','Tue','Wed','Thu','Fri','Sat','Sun']);
   public tripGraphMetadata: any = {
-    graphTitle: "Student Trips",
-    graphSubTitle: "Overview of Total Student Trips",
-    barName: "Trips",
+    graphTitle: 'My Children\'s Trips',
+    graphSubTitle: 'Trips in the selected period',
+    barName: 'Trips',
+  };
+
+  public pieChartData: Partial<piechart>[] = this.buildEmptyCards();
+
+  constructor(private dashboardService: DashboardService) {}
+
+  ngOnInit(): void { this.load(); }
+
+  applyRange(from: Date, to: Date): void {
+    this.range = { from, to };
+    this.load();
   }
 
-  // Creating data for cards
-  public pieChartData: Partial<piechart> | any = [
-    {
-      name: 'Students',
-      sumOfRecords: 2,
-      series: [2, 0],
-      chart: {
-        type: 'donut',
-        fontFamily: 'Poppins,sans-serif',
-        height: 100,
-        offsetY: 0,
-      },
-      plotOptions: {
-        pie: {
-          donut: {
-            size: '85px',
-          },
-        },
-      },
-      stroke: {
-        width: 0,
-      },
-      legend: {
-        show: false,
-      },
-      tooltip: {
-        fillSeriesColor: false,
-      },
-      dataLabels: {
-        enabled: false,
-      },
-      labels: ['Active', 'Inactive'],
-      colors: ['#1e88e5', 'rgba(0, 0, 0, 0.1)'],
-    },
-    {
-      name: 'Guardians',
-      sumOfRecords: 2,
-      series: [1, 1],
-      chart: {
-        type: 'donut',
-        fontFamily: 'Poppins,sans-serif',
-        height: 100,
-        offsetY: 0,
-      },
-      plotOptions: {
-        pie: {
-          donut: {
-            size: '85px',
-          },
-        },
-      },
-      stroke: {
-        width: 0,
-      },
-      legend: {
-        show: false,
-      },
-      tooltip: {
-        fillSeriesColor: false,
-      },
-      dataLabels: {
-        enabled: false,
-      },
-      labels: ['Active', 'Inactive'],
-      colors: ['#ffb22b', 'rgba(0, 0, 0, 0.1)'],
-    },
-    {
-      name: 'Trips This Week',
-      sumOfRecords: 8,
-      series: [7, 1],
-      chart: {
-        type: 'donut',
-        fontFamily: 'Poppins,sans-serif',
-        height: 100,
-        offsetY: 0,
-      },
-      plotOptions: {
-        pie: {
-          donut: {
-            size: '85px',
-          },
-        },
-      },
-      stroke: {
-        width: 0,
-      },
-      legend: {
-        show: false,
-      },
-      tooltip: {
-        fillSeriesColor: false,
-      },
-      dataLabels: {
-        enabled: false,
-      },
-      labels: ['Completed', 'Pending'],
-      colors: ['#26c6da', 'rgba(0, 0, 0, 0.1)'],
-    },
-    {
-      name: 'Invoices',
-      sumOfRecords: 2,
-      series: [2, 0],
-      chart: {
-        type: 'donut',
-        fontFamily: 'Poppins,sans-serif',
-        height: 100,
-        offsetY: 0,
-      },
-      plotOptions: {
-        pie: {
-          donut: {
-            size: '85px',
-          },
-        },
-      },
-      stroke: {
-        width: 0,
-      },
-      legend: {
-        show: false,
-      },
-      tooltip: {
-        fillSeriesColor: false,
-      },
-      dataLabels: {
-        enabled: false,
-      },
-      labels: ['Paid', 'Unpaid'],
-      colors: ['#fc4b6c', 'rgba(0, 0, 0, 0.1)'],
-    }
-  ];
+  private load(): void {
+    this.loading = true;
+    this.dashboardService.getGuardianDashboard(this.range).subscribe({
+      next: data => { this.apply(data); this.loading = false; },
+      error: () => { this.loading = false; },
+    });
+  }
 
+  private apply(data: GuardianDashboardData): void {
+    this.childrenStatus = data.childrenStatus ?? [];
+
+    this.pieChartData = [
+      this.donut('My Children',   data.totalChildren,                   [data.activeChildren, data.totalChildren - data.activeChildren],     ['Active', 'Inactive'], '#1e88e5'),
+      this.donut('Trips',         data.tripsInRange,                    [data.tripsCompletedInRange, data.tripsInRange - data.tripsCompletedInRange], ['Completed', 'Ongoing'], '#26c6da'),
+      this.donut('Billing',       data.paidInvoices + data.overdueInvoices, [data.paidInvoices, data.overdueInvoices],                     ['Paid', 'Overdue'],    '#ffb22b'),
+      this.donut('This Week',     data.tripsInRange,                    [data.tripsCompletedInRange, data.tripsInRange - data.tripsCompletedInRange], ['Done', 'Pending'],    '#fc4b6c'),
+    ];
+
+    this.salesChart = this.buildBarChart(data.dailyTripCounts ?? [], data.dailyTripLabels ?? []);
+  }
+
+  private donut(name: string, total: number, series: number[], labels: string[], color: string): Partial<piechart> {
+    return {
+      name, sumOfRecords: total, series, labels,
+      chart: { type: 'donut', fontFamily: 'Poppins,sans-serif', height: 100, offsetY: 0 },
+      plotOptions: { pie: { donut: { size: '85px' } } },
+      stroke: { width: 0 }, legend: { show: false },
+      tooltip: { fillSeriesColor: false }, dataLabels: { enabled: false },
+      colors: [color, 'rgba(0,0,0,0.1)'],
+    };
+  }
+
+  private buildBarChart(data: number[], labels: string[]): any {
+    const max = data.length ? Math.max(...data, 3) + 3 : 10;
+    return {
+      series: [{ name: 'Trip Count', data }],
+      chart: { type: 'bar', height: 320, offsetX: -15, toolbar: { show: false }, foreColor: '#adb0bb', fontFamily: 'Poppins', sparkline: { enabled: false } },
+      grid: { show: false },
+      plotOptions: { bar: { horizontal: false, columnWidth: '35%', borderRadius: 0 } },
+      dataLabels: { enabled: false },
+      xaxis: { type: 'category', categories: labels },
+      yaxis: { show: true, min: 0, max, tickAmount: 3 },
+      stroke: { show: true, width: 5, lineCap: 'butt', colors: ['transparent'] },
+      legend: { show: false },
+      fill: { colors: ['#26c6da', '#1e88e5'], opacity: 1 },
+      tooltip: { theme: 'dark' },
+    };
+  }
+
+  private buildEmptyCards(): Partial<piechart>[] {
+    return [
+      this.donut('My Children', 0, [0,0], ['Active','Inactive'],    '#1e88e5'),
+      this.donut('Trips',       0, [0,0], ['Completed','Ongoing'],  '#26c6da'),
+      this.donut('Billing',     0, [0,0], ['Paid','Overdue'],       '#ffb22b'),
+      this.donut('This Week',   0, [0,0], ['Done','Pending'],       '#fc4b6c'),
+    ];
+  }
 }

--- a/src/app/pages/dashboards/parent-dashboard/parent-dashboard.component.ts
+++ b/src/app/pages/dashboards/parent-dashboard/parent-dashboard.component.ts
@@ -26,8 +26,7 @@ export class ParentDashboardComponent implements OnInit {
 
   ngOnInit(): void { this.load(); }
 
-  applyRange(from: Date, to: Date): void {
-    this.range = { from, to };
+  applyRange(): void {
     this.load();
   }
 

--- a/src/app/pages/dashboards/school-admin-dashboard/school-admin-dashboard.component.html
+++ b/src/app/pages/dashboards/school-admin-dashboard/school-admin-dashboard.component.html
@@ -1,16 +1,19 @@
 <mat-card class="m-b-16 cardWithShadow">
   <mat-card-content class="p-16">
     <div class="d-flex align-items-center flex-wrap gap-16">
-      <mat-form-field appearance="outline" class="hide-hint" style="min-width:240px">
-        <mat-label>Date range</mat-label>
-        <mat-date-range-input [rangePicker]="picker">
-          <input matStartDate placeholder="From" [(ngModel)]="range.from" />
-          <input matEndDate placeholder="To" [(ngModel)]="range.to" />
-        </mat-date-range-input>
-        <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
-        <mat-date-range-picker #picker></mat-date-range-picker>
+      <mat-form-field appearance="outline" class="hide-hint" style="width:170px">
+        <mat-label>From</mat-label>
+        <input matInput [matDatepicker]="fromPicker" [(ngModel)]="range.from" />
+        <mat-datepicker-toggle matIconSuffix [for]="fromPicker"></mat-datepicker-toggle>
+        <mat-datepicker #fromPicker></mat-datepicker>
       </mat-form-field>
-      <button mat-flat-button color="primary" (click)="applyRange(range.from, range.to)">Apply</button>
+      <mat-form-field appearance="outline" class="hide-hint" style="width:170px">
+        <mat-label>To</mat-label>
+        <input matInput [matDatepicker]="toPicker" [(ngModel)]="range.to" />
+        <mat-datepicker-toggle matIconSuffix [for]="toPicker"></mat-datepicker-toggle>
+        <mat-datepicker #toPicker></mat-datepicker>
+      </mat-form-field>
+      <button mat-flat-button color="primary" (click)="applyRange()">Apply</button>
       @if (loading) { <mat-spinner diameter="20"></mat-spinner> }
     </div>
   </mat-card-content>

--- a/src/app/pages/dashboards/school-admin-dashboard/school-admin-dashboard.component.html
+++ b/src/app/pages/dashboards/school-admin-dashboard/school-admin-dashboard.component.html
@@ -1,4 +1,21 @@
+<mat-card class="m-b-16 cardWithShadow">
+  <mat-card-content class="p-16">
+    <div class="d-flex align-items-center flex-wrap gap-16">
+      <mat-form-field appearance="outline" class="hide-hint" style="min-width:240px">
+        <mat-label>Date range</mat-label>
+        <mat-date-range-input [rangePicker]="picker">
+          <input matStartDate placeholder="From" [(ngModel)]="range.from" />
+          <input matEndDate placeholder="To" [(ngModel)]="range.to" />
+        </mat-date-range-input>
+        <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
+        <mat-date-range-picker #picker></mat-date-range-picker>
+      </mat-form-field>
+      <button mat-flat-button color="primary" (click)="applyRange(range.from, range.to)">Apply</button>
+      @if (loading) { <mat-spinner diameter="20"></mat-spinner> }
+    </div>
+  </mat-card-content>
+</mat-card>
+
 <app-admin-cards [pieChartData]="pieChartData"></app-admin-cards>
-<!--<app-admin-trips-graph [salesChart]="salesChart" [graphMetadata]="tripGraphMetadata"></app-admin-trips-graph>-->
-<app-student-activity-graph [newsletterchartOptions]="newsletterchartOptions"
-                            [graphMetadata]="graphMetadata"></app-student-activity-graph>
+<app-admin-trips-graph [salesChart]="salesChart" [graphMetadata]="tripGraphMetadata"></app-admin-trips-graph>
+<app-student-activity-graph [newsletterchartOptions]="newsletterchartOptions" [graphMetadata]="graphMetadata"></app-student-activity-graph>

--- a/src/app/pages/dashboards/school-admin-dashboard/school-admin-dashboard.component.ts
+++ b/src/app/pages/dashboards/school-admin-dashboard/school-admin-dashboard.component.ts
@@ -32,8 +32,7 @@ export class SchoolAdminDashboardComponent implements OnInit {
 
   ngOnInit(): void { this.load(); }
 
-  applyRange(from: Date, to: Date): void {
-    this.range = { from, to };
+  applyRange(): void {
     this.load();
   }
 

--- a/src/app/pages/dashboards/school-admin-dashboard/school-admin-dashboard.component.ts
+++ b/src/app/pages/dashboards/school-admin-dashboard/school-admin-dashboard.component.ts
@@ -1,313 +1,116 @@
-import {Component} from '@angular/core';
-import {
-  ApexAxisChartSeries,
-  ApexChart,
-  ApexDataLabels,
-  ApexFill,
-  ApexGrid,
-  ApexLegend,
-  ApexMarkers,
-  ApexPlotOptions,
-  ApexStroke,
-  ApexTooltip,
-  ApexXAxis,
-  ApexYAxis
-} from "ng-apexcharts";
-import {piechart} from "../harmony-admin-dashboard/admin-cards/admin-cards.component";
-
-export interface newsletterchartOptions {
-  series: ApexAxisChartSeries | any;
-  chart: ApexChart | any;
-  xaxis: ApexXAxis | any;
-  stroke: any | any;
-  tooltip: ApexTooltip | any;
-  dataLabels: ApexDataLabels | any;
-  legend: ApexLegend | any;
-  colors: string[] | any;
-  markers: any;
-  grid: ApexGrid | any;
-  fill: ApexFill | any;
-}
-
-export interface salesChart {
-  series: ApexAxisChartSeries | any;
-  chart: ApexChart | any;
-  dataLabels: ApexDataLabels | any;
-  plotOptions: ApexPlotOptions | any;
-  yaxis: ApexYAxis | any;
-  xaxis: ApexXAxis | any;
-  fill: ApexFill | any;
-  tooltip: ApexTooltip | any;
-  stroke: ApexStroke | any;
-  legend: ApexLegend | any;
-  grid: ApexGrid | any;
-  marker: ApexMarkers | any;
-}
-
+import { Component, OnInit } from '@angular/core';
+import { piechart } from '../harmony-admin-dashboard/admin-cards/admin-cards.component';
+import { DashboardService, DateRange, SchoolAdminDashboardData } from 'src/app/services/dashboard.service';
 
 @Component({
     selector: 'app-school-admin-dashboard',
     templateUrl: './school-admin-dashboard.component.html',
     standalone: false
 })
-export class SchoolAdminDashboardComponent {
-  // Creating data to feed into the student activity graph
-  public newsletterchartOptions: Partial<newsletterchartOptions> | any = {
-    series: [
-      {
-        name: 'Registered Student',
-        data: [250, 390, 485, 485, 490, 515, 530, 546],
-      },
-      {
-        name: 'Paying Students',
-        data: [245, 360, 478, 480, 480, 500, 530, 530],
-      },
-    ],
-    chart: {
-      height: 365,
-      fontFamily: 'Poppins,sans-serif',
-      type: 'area',
-      foreColor: '#adb0bb',
-    },
-    colors: ['#1e88e5', '#26c6da'],
-    dataLabels: {
-      enabled: false,
-    },
-    markers: {
-      size: 4,
-      border: 1,
-    },
-    legend: {
-      show: false,
-    },
-    xaxis: {
-      categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug'],
-    },
-    grid: {
-      show: true,
-      borderColor: 'rgba(0, 0, 0, .2)',
-      color: 'rgba(0, 0, 0, .2)',
-      strokeDashArray: 2,
-      xaxis: {
-        lines: {
-          show: false,
-        },
-      },
-      yaxis: {
-        lines: {
-          show: true,
-        },
-      },
-    },
-    stroke: {
-      curve: 'smooth',
-      width: 3,
-    },
-    fill: {
-      type: 'gradient',
-      opacity: ['0.1', '0.1'],
-    },
-    tooltip: {
-      theme: 'dark',
-      x: {
-        format: 'dd/MM/yy HH:mm',
-      },
-    },
-  };
+export class SchoolAdminDashboardComponent implements OnInit {
+  range: DateRange = this.dashboardService.defaultRange();
+  loading = false;
+
+  public newsletterchartOptions: any = this.buildAreaChart([0,0,0,0,0,0],[0,0,0,0,0,0],['Jan','Feb','Mar','Apr','May','Jun']);
   public graphMetadata: any = {
-    graphTitle: "Students Retaining Rate",
-    graphSubTitle: "Overview of Total Vs Paying Students",
-    lineGraphName1: "Registered Students",
-    lineGraphName2: "Paying Students"
-  }
-
-
-  // Creating data for the school trips graph
-  public salesChart: Partial<salesChart> | any = {
-    series: [
-      {name: 'Trip Count', data: [20, 18, 25, 19, 21, 2, 0]}
-    ],
-    chart: {
-      type: 'bar',
-      height: 320,
-      offsetX: -15,
-      toolbar: {show: false},
-      foreColor: '#adb0bb',
-      fontFamily: 'Poppins',
-      sparkline: {enabled: false},
-    },
-    grid: {
-      show: false,
-    },
-    plotOptions: {
-      bar: {horizontal: false, columnWidth: '35%', borderRadius: 0},
-    },
-    dataLabels: {
-      enabled: false,
-    },
-    xaxis: {
-      type: 'category',
-      categories: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
-    },
-    yaxis: {
-      show: true,
-      min: 0,
-      max: 30,
-      tickAmount: 3,
-    },
-    stroke: {
-      show: true,
-      width: 5,
-      lineCap: 'butt',
-      colors: ['transparent'],
-    },
-
-    legend: {
-      show: false,
-    },
-    fill: {
-      colors: ['#26c6da', '#1e88e5'],
-      opacity: 1,
-    },
-    tooltip: {
-      theme: 'dark',
-    },
+    graphTitle: 'Students Retaining Rate',
+    graphSubTitle: 'Overview of Total Vs Paying Students',
+    lineGraphName1: 'Registered Students',
+    lineGraphName2: 'Paying Students',
   };
+
+  public salesChart: any = this.buildBarChart([0,0,0,0,0,0,0], ['Mon','Tue','Wed','Thu','Fri','Sat','Sun']);
   public tripGraphMetadata: any = {
-    graphTitle: "Student Trips",
-    graphSubTitle: "Overview of Total Student Trips",
-    barName: "Trips",
+    graphTitle: 'Student Trips',
+    graphSubTitle: 'Overview of Total Student Trips',
+    barName: 'Trips',
+  };
+
+  public pieChartData: Partial<piechart>[] = this.buildEmptyCards();
+
+  constructor(private dashboardService: DashboardService) {}
+
+  ngOnInit(): void { this.load(); }
+
+  applyRange(from: Date, to: Date): void {
+    this.range = { from, to };
+    this.load();
   }
 
-  // Creating data for cards
-  public pieChartData: Partial<piechart> | any = [
-    {
-      name: 'Drivers',
-      sumOfRecords: 4,
-      series: [3, 1],
-      chart: {
-        type: 'donut',
-        fontFamily: 'Poppins,sans-serif',
-        height: 100,
-        offsetY: 0,
-      },
-      plotOptions: {
-        pie: {
-          donut: {
-            size: '85px',
-          },
-        },
-      },
-      stroke: {
-        width: 0,
-      },
-      legend: {
-        show: false,
-      },
-      tooltip: {
-        fillSeriesColor: false,
-      },
-      dataLabels: {
-        enabled: false,
-      },
-      labels: ['Active', 'Inactive'],
-      colors: ['#1e88e5', 'rgba(0, 0, 0, 0.1)'],
-    },
-    {
-      name: 'Cars',
-      sumOfRecords: 4,
-      series: [4, 0],
-      chart: {
-        type: 'donut',
-        fontFamily: 'Poppins,sans-serif',
-        height: 100,
-        offsetY: 0,
-      },
-      plotOptions: {
-        pie: {
-          donut: {
-            size: '85px',
-          },
-        },
-      },
-      stroke: {
-        width: 0,
-      },
-      legend: {
-        show: false,
-      },
-      tooltip: {
-        fillSeriesColor: false,
-      },
-      dataLabels: {
-        enabled: false,
-      },
-      labels: ['Online', 'Offline'],
-      colors: ['#26c6da', 'rgba(0, 0, 0, 0.1)'],
-    },
-    {
-      name: 'Students',
-      sumOfRecords: 546,
-      series: [516, 30],
-      chart: {
-        type: 'donut',
-        fontFamily: 'Poppins,sans-serif',
-        height: 100,
-        offsetY: 0,
-      },
-      plotOptions: {
-        pie: {
-          donut: {
-            size: '85px',
-          },
-        },
-      },
-      stroke: {
-        width: 0,
-      },
-      legend: {
-        show: false,
-      },
-      tooltip: {
-        fillSeriesColor: false,
-      },
-      dataLabels: {
-        enabled: false,
-      },
-      labels: ['Active', 'Inactive'],
-      colors: ['#ffb22b', 'rgba(0, 0, 0, 0.1)'],
-    },
-    {
-      name: 'Invoices',
-      sumOfRecords: 2,
-      series: [2, 0],
-      chart: {
-        type: 'donut',
-        fontFamily: 'Poppins,sans-serif',
-        height: 100,
-        offsetY: 0,
-      },
-      plotOptions: {
-        pie: {
-          donut: {
-            size: '85px',
-          },
-        },
-      },
-      stroke: {
-        width: 0,
-      },
-      legend: {
-        show: false,
-      },
-      tooltip: {
-        fillSeriesColor: false,
-      },
-      dataLabels: {
-        enabled: false,
-      },
-      labels: ['Paid', 'Unpaid'],
-      colors: ['#fc4b6c', 'rgba(0, 0, 0, 0.1)'],
-    }
-  ];
+  private load(): void {
+    this.loading = true;
+    this.dashboardService.getSchoolAdminDashboard(this.range).subscribe({
+      next: data => { this.apply(data); this.loading = false; },
+      error: () => { this.loading = false; },
+    });
+  }
+
+  private apply(data: SchoolAdminDashboardData): void {
+    this.pieChartData = [
+      this.donut('Drivers',  data.totalDrivers,  [data.activeDrivers,   data.inactiveDrivers],  ['Active','Inactive'], '#1e88e5'),
+      this.donut('Fleets',   data.totalFleets,   [data.activeFleets,    data.inactiveFleets],   ['Active','Inactive'], '#26c6da'),
+      this.donut('Students', data.totalStudents, [data.activeStudents,  data.inactiveStudents], ['Active','Inactive'], '#ffb22b'),
+      this.donut('Billing',  data.billingsPaid + data.billingsOverdue, [data.billingsPaid, data.billingsOverdue], ['Paid','Overdue'], '#fc4b6c'),
+    ];
+    this.salesChart = this.buildBarChart(data.dailyTripCounts ?? [], data.dailyTripLabels ?? []);
+    this.newsletterchartOptions = this.buildAreaChart(
+      data.monthlyStudentTotals ?? [],
+      data.monthlyPayingStudents ?? [],
+      data.monthlyLabels ?? []
+    );
+  }
+
+  private donut(name: string, total: number, series: number[], labels: string[], color: string): Partial<piechart> {
+    return {
+      name, sumOfRecords: total, series, labels,
+      chart: { type: 'donut', fontFamily: 'Poppins,sans-serif', height: 100, offsetY: 0 },
+      plotOptions: { pie: { donut: { size: '85px' } } },
+      stroke: { width: 0 }, legend: { show: false },
+      tooltip: { fillSeriesColor: false }, dataLabels: { enabled: false },
+      colors: [color, 'rgba(0,0,0,0.1)'],
+    };
+  }
+
+  private buildBarChart(data: number[], labels: string[]): any {
+    const max = data.length ? Math.max(...data, 5) + 5 : 30;
+    return {
+      series: [{ name: 'Trip Count', data }],
+      chart: { type: 'bar', height: 320, offsetX: -15, toolbar: { show: false }, foreColor: '#adb0bb', fontFamily: 'Poppins', sparkline: { enabled: false } },
+      grid: { show: false },
+      plotOptions: { bar: { horizontal: false, columnWidth: '35%', borderRadius: 0 } },
+      dataLabels: { enabled: false },
+      xaxis: { type: 'category', categories: labels },
+      yaxis: { show: true, min: 0, max, tickAmount: 3 },
+      stroke: { show: true, width: 5, lineCap: 'butt', colors: ['transparent'] },
+      legend: { show: false },
+      fill: { colors: ['#26c6da', '#1e88e5'], opacity: 1 },
+      tooltip: { theme: 'dark' },
+    };
+  }
+
+  private buildAreaChart(registered: number[], paying: number[], labels: string[]): any {
+    return {
+      series: [
+        { name: 'Registered Students', data: registered },
+        { name: 'Paying Students', data: paying },
+      ],
+      chart: { height: 365, fontFamily: 'Poppins,sans-serif', type: 'area', foreColor: '#adb0bb' },
+      colors: ['#1e88e5', '#26c6da'], dataLabels: { enabled: false },
+      markers: { size: 4, border: 1 }, legend: { show: false },
+      xaxis: { categories: labels },
+      grid: { show: true, borderColor: 'rgba(0,0,0,.2)', strokeDashArray: 2, xaxis: { lines: { show: false } }, yaxis: { lines: { show: true } } },
+      stroke: { curve: 'smooth', width: 3 },
+      fill: { type: 'gradient', opacity: ['0.1', '0.1'] },
+      tooltip: { theme: 'dark' },
+    };
+  }
+
+  private buildEmptyCards(): Partial<piechart>[] {
+    return [
+      this.donut('Drivers',  0, [0, 0], ['Active', 'Inactive'], '#1e88e5'),
+      this.donut('Fleets',   0, [0, 0], ['Active', 'Inactive'], '#26c6da'),
+      this.donut('Students', 0, [0, 0], ['Active', 'Inactive'], '#ffb22b'),
+      this.donut('Billing',  0, [0, 0], ['Paid',   'Overdue'],  '#fc4b6c'),
+    ];
+  }
 }

--- a/src/app/services/dashboard.service.ts
+++ b/src/app/services/dashboard.service.ts
@@ -1,0 +1,98 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environment';
+
+export interface DateRange { from: Date; to: Date; }
+
+export interface RecentTrip {
+  id: number; tripType: string; tripStatus: string;
+  startTime: string; endTime: string | null;
+}
+export interface RecentSchool { id: number; name: string; entityStatus: string; }
+export interface RecentStudent { id: number; name: string; classLevel: string; billingStatus: string; }
+export interface StudentBoardingItem {
+  id: number; studentName: string; classLevel: string;
+  boardingStatus: string; pickupTime: string | null;
+}
+export interface ChildStatus {
+  id: number; name: string; classLevel: string; billingStatus: string;
+  boardingStatus: string; fleetNumberPlate: string; lastTripDate: string | null;
+}
+
+export interface AdminDashboardData {
+  totalSchools: number; activeSchools: number; inactiveSchools: number;
+  totalTerminals: number; onlineTerminals: number; offlineTerminals: number;
+  totalStudents: number; activeStudents: number; inactiveStudents: number;
+  totalDrivers: number; activeDrivers: number;
+  tripsInRange: number; tripsCompleted: number; tripsOngoing: number;
+  dailyTripCounts: number[]; dailyTripLabels: string[];
+  monthlyStudentTotals: number[]; monthlyPayingStudents: number[]; monthlyLabels: string[];
+  recentTrips: RecentTrip[]; recentSchools: RecentSchool[];
+}
+
+export interface SchoolAdminDashboardData {
+  totalDrivers: number; activeDrivers: number; inactiveDrivers: number;
+  totalFleets: number; activeFleets: number; inactiveFleets: number;
+  totalStudents: number; activeStudents: number; inactiveStudents: number;
+  billingsPaid: number; billingsOverdue: number;
+  tripsInRange: number; tripsCompleted: number;
+  dailyTripCounts: number[]; dailyTripLabels: string[];
+  monthlyStudentTotals: number[]; monthlyPayingStudents: number[]; monthlyLabels: string[];
+  recentStudents: RecentStudent[]; recentTrips: RecentTrip[];
+}
+
+export interface DriverDashboardData {
+  totalStudentsOnFleet: number;
+  boardedInRange: number; pendingInRange: number; droppedOffInRange: number;
+  tripsCompletedInRange: number; tripsTotalInRange: number;
+  fleetNumberPlate: string; terminalStatus: string;
+  dailyTripCounts: number[]; dailyTripLabels: string[];
+  currentTripRoster: StudentBoardingItem[]; recentTrips: RecentTrip[];
+}
+
+export interface GuardianDashboardData {
+  totalChildren: number; activeChildren: number;
+  tripsInRange: number; tripsCompletedInRange: number;
+  paidInvoices: number; overdueInvoices: number;
+  dailyTripCounts: number[]; dailyTripLabels: string[];
+  childrenStatus: ChildStatus[]; recentChildTrips: RecentTrip[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class DashboardService {
+  private readonly base = `${environment.apiUrl}dashboard`;
+
+  constructor(private http: HttpClient) {}
+
+  defaultRange(): DateRange {
+    const to = new Date();
+    const from = new Date();
+    const day = from.getDay();
+    from.setDate(from.getDate() - (day === 0 ? 6 : day - 1));
+    from.setHours(0, 0, 0, 0);
+    return { from, to };
+  }
+
+  getAdminDashboard(range: DateRange): Observable<AdminDashboardData> {
+    return this.http.get<AdminDashboardData>(`${this.base}/admin`, { params: this.params(range) });
+  }
+
+  getSchoolAdminDashboard(range: DateRange): Observable<SchoolAdminDashboardData> {
+    return this.http.get<SchoolAdminDashboardData>(`${this.base}/school-admin`, { params: this.params(range) });
+  }
+
+  getDriverDashboard(range: DateRange): Observable<DriverDashboardData> {
+    return this.http.get<DriverDashboardData>(`${this.base}/driver`, { params: this.params(range) });
+  }
+
+  getGuardianDashboard(range: DateRange): Observable<GuardianDashboardData> {
+    return this.http.get<GuardianDashboardData>(`${this.base}/guardian`, { params: this.params(range) });
+  }
+
+  private params(range: DateRange): HttpParams {
+    return new HttpParams()
+      .set('from', range.from.toISOString())
+      .set('to', range.to.toISOString());
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `DashboardService` (`src/app/services/dashboard.service.ts`) with typed interfaces and HTTP methods for all 4 role dashboard endpoints
- Replaces hardcoded placeholder data in all 4 dashboard components with live API calls: Harmony Admin, School Admin, Driver, Guardian
- Adds date-range picker (`mat-date-range-input`) to each dashboard; clicking Apply re-fetches with the chosen range
- Driver dashboard shows live boarding roster table with `mat-progress-bar` progress indicator
- Guardian dashboard shows per-child status cards with boarding badge, billing badge, and last trip date
- `dashboards.module.ts` updated with all required Material imports

## Test plan
- [ ] Log in as admin → Harmony Admin dashboard shows real school/terminal/student/driver counts and trip bar chart
- [ ] Log in as test-user (school admin) → School Admin dashboard shows 2 fleets, 20 students, 16 paid / 4 overdue billing
- [ ] Log in as test-driver → Driver dashboard shows fleet KBA 001A, terminal ONLINE, live boarding roster with 5 BOARDED / 5 PENDING students
- [ ] Log in as test-guardian → Guardian dashboard shows 2 children (Amara + Brian Wangari), both BOARDED on KBA 001A
- [ ] Change date range and click Apply → charts update with filtered data
- [ ] Verify empty states: no active trip shows "No active trip at the moment", no children shows "No children linked"

🤖 Generated with [Claude Code](https://claude.com/claude-code)