### PR TITLE
feat: dynamic parent-selector dropdowns and post-CRUD table refresh

### DIFF
--- a/src/app/pages/apps/drivers/drivers.component.ts
+++ b/src/app/pages/apps/drivers/drivers.component.ts
@@ -118,5 +118,6 @@ export class DriversComponent extends CrudActions implements OnInit {
     });
   }
 
-}
 
+  protected override onSuccess(): void { this.getRecords(); }
+}

--- a/src/app/pages/apps/forms/driver-registration-form-config.ts
+++ b/src/app/pages/apps/forms/driver-registration-form-config.ts
@@ -146,7 +146,26 @@ export const driverForm: IForm = {
           "message": "Entity status is Required"
         }
       ]
+    },
+    {
+      "name": "fleet",
+      "label": "Fleet (Vehicle)",
+      "value": "",
+      "placeholder": "Select Fleet",
+      "class": "col-sm-12 d-flex align-items-center",
+      "type": "select",
+      "options": [],
+      "apiEndpoint": "fleets",
+      "optionLabel": "numberPlate",
+      "optionValue": "id",
+      "isRelation": true,
+      "validators": [
+        {
+          "validatorName": "required",
+          "pattern": "",
+          "message": "Fleet is required."
+        }
+      ]
     }
-
   ]
 }

--- a/src/app/pages/apps/forms/interfaces/form-controls.ts
+++ b/src/app/pages/apps/forms/interfaces/form-controls.ts
@@ -3,12 +3,16 @@ import {Validators} from "./validators";
 export interface FormControls {
   name: string;
   label: string;
-  value: string;
+  value: any;
   placeholder: string;
   class: string;
   type: string;
   validators: Validators[];
-  options?: { label: string, value: string }[];
+  options?: { label: string, value: any }[];
   minAge?: number;
   displayInput?: boolean;
+  apiEndpoint?: string;
+  optionLabel?: string;
+  optionValue?: string;
+  isRelation?: boolean;
 }

--- a/src/app/pages/apps/forms/school-registration-form-config.ts
+++ b/src/app/pages/apps/forms/school-registration-form-config.ts
@@ -3,7 +3,7 @@ import {IForm} from "./interfaces/IForm";
 export const schoolForm: IForm = {
   formTitle: 'School',
   saveBtnTitle: 'Save School',
-  resetBtnTitle: 'Reset',
+  resetBtnTitle: 'Cancel',
   displayColumns: [
     'id',
     'name',

--- a/src/app/pages/apps/forms/school-registration-form-config.ts
+++ b/src/app/pages/apps/forms/school-registration-form-config.ts
@@ -100,12 +100,26 @@ export const schoolForm: IForm = {
       "placeholder": "Choose an image...",
       "class": "col-md-6",
       "type": "file",
+      "validators": []
+    },
+    {
+      "name": "organization",
+      "label": "Organization",
+      "value": "",
+      "placeholder": "Select Organization",
+      "class": "col-sm-12 d-flex align-items-center",
+      "type": "select",
+      "options": [],
+      "apiEndpoint": "organizations",
+      "optionLabel": "name",
+      "optionValue": "id",
+      "isRelation": true,
       "validators": [
-        // {
-        //   "validatorName": "required",
-        //   "pattern": "",
-        //   "message": "Image file is required"
-        // }
+        {
+          "validatorName": "required",
+          "pattern": "",
+          "message": "Organization is required."
+        }
       ]
     }
     /*

--- a/src/app/pages/apps/forms/school-stuff-form-config.ts
+++ b/src/app/pages/apps/forms/school-stuff-form-config.ts
@@ -135,16 +135,34 @@ export const schoolStuffForm: IForm = {
         {"label": "Bursar", "value": "BURSAR"},
         {"label": "Transport Manager", "value": "TRANSPORT_MANAGER"},
         {"label": "Secretary", "value": "SECRETARY"}
-
       ],
       "validators": [
         {
           "validatorName": "required",
           "pattern": "",
-          "message": "Email address is Required"
+          "message": "Role description is required."
         }
       ]
     },
-
+    {
+      "name": "school",
+      "label": "School",
+      "value": "",
+      "placeholder": "Select School",
+      "class": "col-sm-12 d-flex align-items-center",
+      "type": "select",
+      "options": [],
+      "apiEndpoint": "schools",
+      "optionLabel": "name",
+      "optionValue": "id",
+      "isRelation": true,
+      "validators": [
+        {
+          "validatorName": "required",
+          "pattern": "",
+          "message": "School is required."
+        }
+      ]
+    }
   ]
 }

--- a/src/app/pages/apps/forms/student-billings-form-config.ts
+++ b/src/app/pages/apps/forms/student-billings-form-config.ts
@@ -1,60 +1,53 @@
 import {IForm} from "./interfaces/IForm";
 
-export const tripForm: IForm = {
-  formTitle: 'Trip',
-  saveBtnTitle: 'Save Trip',
+export const studentBillingsForm: IForm = {
+  formTitle: 'Invoice',
+  saveBtnTitle: 'Save Invoice',
   resetBtnTitle: 'Cancel',
   displayColumns: [
     'id',
-    'tripType',
+    'paymentChannel',
+    'paymentReference',
+    'subscriptionStart',
+    'subscriptionEnd',
     'action',
   ],
   formControls: [
     {
-      "name": "tripType",
-      "label": "Trip Type",
+      "name": "paymentChannel",
+      "label": "Payment Channel",
       "value": "",
-      "placeholder": "Select Trip Type",
-      "class": "col-sm-12 d-flex align-items-center",
-      "type": "select",
+      "placeholder": "e.g. MPESA",
+      "class": "col-md-6",
+      "type": "text",
       "displayInput": true,
-      "options": [
-        {"label": "Dropoff", "value": "DROPOFF"},
-        {"label": "Field Trip", "value": "FIELDTRIP"},
-        {"label": "Pickup", "value": "PICKUP"}
-      ],
       "validators": [
         {
           "validatorName": "required",
           "pattern": "",
-          "message": "Trip type is required."
+          "message": "Payment channel is required."
         }
       ]
     },
     {
-      "name": "tripStatus",
-      "label": "Trip Status",
+      "name": "paymentReference",
+      "label": "Payment Reference",
       "value": "",
-      "placeholder": "Select Trip Status",
-      "class": "col-sm-12 d-flex align-items-center",
-      "type": "select",
+      "placeholder": "e.g. QK7E2X1P",
+      "class": "col-md-6",
+      "type": "text",
       "displayInput": true,
-      "options": [
-        {"label": "Started", "value": "STARTED"},
-        {"label": "Ongoing", "value": "ONGOING"},
-        {"label": "Completed", "value": "COMPLETED"}
-      ],
       "validators": [
         {
           "validatorName": "required",
           "pattern": "",
-          "message": "Trip status is required."
+          "message": "Payment reference is required."
         }
       ]
     },
     {
-      "name": "startTime",
-      "label": "Start Time",
+      "name": "subscriptionStart",
+      "label": "Subscription Start",
       "value": "",
       "placeholder": "YYYY-MM-DDTHH:MM",
       "class": "col-md-6",
@@ -63,8 +56,8 @@ export const tripForm: IForm = {
       "validators": []
     },
     {
-      "name": "endTime",
-      "label": "End Time",
+      "name": "subscriptionEnd",
+      "label": "Subscription End",
       "value": "",
       "placeholder": "YYYY-MM-DDTHH:MM",
       "class": "col-md-6",
@@ -73,22 +66,23 @@ export const tripForm: IForm = {
       "validators": []
     },
     {
-      "name": "driverId",
-      "label": "Driver",
+      "name": "student",
+      "label": "Student",
       "value": "",
-      "placeholder": "Select Driver",
+      "placeholder": "Select Student",
       "class": "col-sm-12 d-flex align-items-center",
       "type": "select",
       "displayInput": true,
       "options": [],
-      "apiEndpoint": "drivers",
+      "apiEndpoint": "students",
       "optionLabel": "name",
       "optionValue": "id",
+      "isRelation": true,
       "validators": [
         {
           "validatorName": "required",
           "pattern": "",
-          "message": "Driver is required."
+          "message": "Student is required."
         }
       ]
     }

--- a/src/app/pages/apps/forms/student-registration-form-config.ts
+++ b/src/app/pages/apps/forms/student-registration-form-config.ts
@@ -188,12 +188,49 @@ export const studentForm: IForm = {
           "validatorName": "pattern",
           "pattern": "^-?\\d{1,2}(\\.\\d+)?$",
           "message": "Latitude must be a valid number between -90 and 90."
-        },
-        // {
-        //   "validatorName": "required",
-        //   "pattern": "",
-        //   "message": "Latitude is required."
-        // }
+        }
+      ]
+    },
+    {
+      "name": "fleet",
+      "label": "Fleet (Vehicle)",
+      "value": "",
+      "placeholder": "Select Fleet",
+      "class": "col-sm-12 d-flex align-items-center",
+      "type": "select",
+      "displayInput": true,
+      "options": [],
+      "apiEndpoint": "fleets",
+      "optionLabel": "numberPlate",
+      "optionValue": "id",
+      "isRelation": true,
+      "validators": [
+        {
+          "validatorName": "required",
+          "pattern": "",
+          "message": "Fleet is required."
+        }
+      ]
+    },
+    {
+      "name": "guardian",
+      "label": "Guardian",
+      "value": "",
+      "placeholder": "Select Guardian",
+      "class": "col-sm-12 d-flex align-items-center",
+      "type": "select",
+      "displayInput": true,
+      "options": [],
+      "apiEndpoint": "guardians",
+      "optionLabel": "name",
+      "optionValue": "id",
+      "isRelation": true,
+      "validators": [
+        {
+          "validatorName": "required",
+          "pattern": "",
+          "message": "Guardian is required."
+        }
       ]
     }
     // {

--- a/src/app/pages/apps/forms/terminals-form-config.ts
+++ b/src/app/pages/apps/forms/terminals-form-config.ts
@@ -20,11 +20,44 @@ export const terminalForm: IForm = {
       "placeholder": "e.g 223344556",
       "class": "col-sm-12 d-flex align-items-center",
       "type": "text",
+      "displayInput": true,
       "validators": [
         {
           "validatorName": "required",
           "pattern": "",
           "message": "Device ID is required."
+        }
+      ]
+    },
+    {
+      "name": "manufacturer",
+      "label": "Manufacturer",
+      "value": "",
+      "placeholder": "e.g. Teltonika",
+      "class": "col-md-6",
+      "type": "text",
+      "displayInput": true,
+      "validators": [
+        {
+          "validatorName": "required",
+          "pattern": "",
+          "message": "Manufacturer is required."
+        }
+      ]
+    },
+    {
+      "name": "model",
+      "label": "Model",
+      "value": "",
+      "placeholder": "e.g. FMB920",
+      "class": "col-md-6",
+      "type": "text",
+      "displayInput": true,
+      "validators": [
+        {
+          "validatorName": "required",
+          "pattern": "",
+          "message": "Model is required."
         }
       ]
     },
@@ -35,6 +68,7 @@ export const terminalForm: IForm = {
       "placeholder": "e.g. +254712345678",
       "class": "col-md-6",
       "type": "text",
+      "displayInput": true,
       "validators": [
         {
           "validatorName": "pattern",

--- a/src/app/pages/apps/forms/vehicle-registration-form-config.ts
+++ b/src/app/pages/apps/forms/vehicle-registration-form-config.ts
@@ -20,16 +20,17 @@ export const vehicleForm: IForm = {
       "placeholder": "e.g KDP 099Y",
       "class": "col-sm-12 d-flex align-items-center",
       "type": "text",
+      "displayInput": true,
       "validators": [
         {
           "validatorName": "pattern",
           "pattern": "^[a-zA-Z0-9\\s]+$",
-          "message": "Number plate should have number and text only"
+          "message": "Number plate should contain numbers and letters only."
         },
         {
           "validatorName": "required",
           "pattern": "",
-          "message": "Student name is Required"
+          "message": "Number plate is required."
         }
       ]
     },
@@ -48,9 +49,56 @@ export const vehicleForm: IForm = {
         {
           "validatorName": "required",
           "pattern": "",
-          "message": "Entity status is Required"
+          "message": "Vehicle type is required."
         }
       ]
+    },
+    {
+      "name": "entityStatus",
+      "label": "Status",
+      "value": "",
+      "placeholder": "Select Status",
+      "class": "col-sm-12 d-flex align-items-center",
+      "type": "select",
+      "options": [
+        {"label": "Active", "value": "ACTIVE"},
+        {"label": "Inactive", "value": "INACTIVE"}
+      ],
+      "validators": []
+    },
+    {
+      "name": "school",
+      "label": "School",
+      "value": "",
+      "placeholder": "Select School",
+      "class": "col-sm-12 d-flex align-items-center",
+      "type": "select",
+      "options": [],
+      "apiEndpoint": "schools",
+      "optionLabel": "name",
+      "optionValue": "id",
+      "isRelation": true,
+      "validators": [
+        {
+          "validatorName": "required",
+          "pattern": "",
+          "message": "School is required."
+        }
+      ]
+    },
+    {
+      "name": "terminal",
+      "label": "Terminal",
+      "value": "",
+      "placeholder": "Select Terminal",
+      "class": "col-sm-12 d-flex align-items-center",
+      "type": "select",
+      "options": [],
+      "apiEndpoint": "terminals",
+      "optionLabel": "devideId",
+      "optionValue": "id",
+      "isRelation": true,
+      "validators": []
     }
   ]
 }

--- a/src/app/pages/apps/guardians/guardians.component.ts
+++ b/src/app/pages/apps/guardians/guardians.component.ts
@@ -129,6 +129,6 @@ export class GuardiansComponent extends CrudActions implements OnInit {
     });
   }
 
+
+  protected override onSuccess(): void { this.getRecords(); }
 }
-
-

--- a/src/app/pages/apps/invoices/invoices.component.ts
+++ b/src/app/pages/apps/invoices/invoices.component.ts
@@ -3,7 +3,7 @@ import {MatDialog} from "@angular/material/dialog";
 import { HttpClient } from "@angular/common/http";
 import {SchoolViewComponent} from "../schools/school-view/school-view.component";
 import {CrudActions} from "../reusable/CrudActions";
-import {organizationForm} from "../forms/institution-registration-form-config";
+import {studentBillingsForm} from "../forms/student-billings-form-config";
 import {IForm} from "../forms/interfaces/IForm";
 import {EntityAction} from "../reusable/EntityAction";
 
@@ -85,7 +85,7 @@ import {EntityAction} from "../reusable/EntityAction";
     standalone: false
 })
 export class InvoicesComponent extends CrudActions implements OnInit {
-  recordForm = organizationForm as IForm;
+  recordForm = studentBillingsForm as IForm;
   displayedColumns: string[];
   tableHeading: string;
   tableData: any[];
@@ -182,5 +182,6 @@ export class InvoicesComponent extends CrudActions implements OnInit {
     });
   }
 
-}
 
+  protected override onSuccess(): void { this.getRecords(); }
+}

--- a/src/app/pages/apps/organizations/organizations.component.ts
+++ b/src/app/pages/apps/organizations/organizations.component.ts
@@ -110,4 +110,6 @@ export class OrganizationsComponent extends CrudActions implements OnInit {
     });
   }
 
+
+  protected override onSuccess(): void { this.getRecords(); }
 }

--- a/src/app/pages/apps/reusable/CrudActions.ts
+++ b/src/app/pages/apps/reusable/CrudActions.ts
@@ -210,6 +210,8 @@ export class CrudActions {
    * @param entity
    * @param dialogComponent
    */
+  protected onSuccess(): void {}
+
   handleApiRecordResponse(
       res: any,
       entity: EntityAction,
@@ -223,6 +225,7 @@ export class CrudActions {
         message: 'Actioned '.concat(entity.name).concat(' successfully: ').concat(res.name),
       },
     });
+    this.onSuccess();
   }
 
 
@@ -246,10 +249,16 @@ export class CrudActions {
   // Helper method to populate form with existing data
   public prepareFormWithData(record: EntityAction, form: IForm): IForm {
     const populatedForm = {...form};
-    populatedForm.formControls = populatedForm.formControls.map(control => ({
-      ...control,
-      value: record.data[control.name] ?? control.value
-    }));
+    populatedForm.formControls = populatedForm.formControls.map(control => {
+      const raw = record.data[control.name];
+      let value: any;
+      if (control.isRelation && raw && typeof raw === 'object') {
+        value = raw.id;
+      } else {
+        value = raw ?? control.value;
+      }
+      return { ...control, value };
+    });
     return populatedForm;
   }
 

--- a/src/app/pages/apps/reusable/dynamic-form/dynamic-form.component.html
+++ b/src/app/pages/apps/reusable/dynamic-form/dynamic-form.component.html
@@ -1,185 +1,175 @@
 <script
   src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDk78IBulZVCNl2SGPDSExuDX2poBlrZIA&libraries=places"></script>
-<!-- map.component.html -->
 <div class="col-lg-12">
   <mat-card class="cardWithShadow theme-card">
-    <!--    <mat-card-header>-->
-    <!--      <mat-card-title class="m-b-0">{{ form.formTitle }}</mat-card-title>-->
-    <!--    </mat-card-header>-->
     <mat-card-content class="b-t-1">
       <form [formGroup]="dynamicFormGroup">
 
         <div class="row">
           <div class="col-lg-12 col-sm-12">
 
-            <div *ngFor="let control of form.formControls" class="row">
+            <!-- File upload fields rendered first -->
+            <ng-container *ngFor="let control of form.formControls">
+              <div class="col-sm-12 m-b-16" *ngIf="control.type === 'file'">
 
-              <!-- Display this label if field is a text, email, password, number, date, or select (dropdown)-->
-              <div *ngIf="['text', 'email', 'password', 'number', 'date', 'select', 'map'].includes(control.type)
-              && control.displayInput === true" [class]="control?.class">
-                <mat-label class="mat-subtitle-2 f-w-600 d-block m-b-16">
-                  {{ control.label }}
-                </mat-label>
-              </div>
+                <!-- Circular image preview (existing or newly uploaded) -->
+                <div *ngIf="dynamicFormGroup.get(control.name)?.value"
+                     class="m-b-12 d-flex justify-content-center">
+                  <img [src]="dynamicFormGroup.get(control.name)?.value"
+                       style="width:120px;height:120px;border-radius:50%;object-fit:cover;border:2px solid #ddd;"
+                       alt="Profile image" />
+                </div>
 
-              <!-- Display date input -->
-              <div class="col-sm-12" *ngIf="control.type === 'date'">
-                <mat-form-field appearance="outline" class="w-100">
-                  <input matInput [matDatepicker]="birthpicker"
-                         placeholder="{{control.placeholder}}"
-                         formControlName="{{control?.name}}"/>
-                  <mat-datepicker-toggle matIconSuffix [for]="birthpicker"></mat-datepicker-toggle>
-                  <mat-datepicker #birthpicker></mat-datepicker>
-                </mat-form-field>
-              </div>
-
-              <!-- Display text, email, password, number input -->
-              <div class="col-sm-12"
-                   *ngIf="['text', 'email', 'password', 'number'].includes(control.type)">
-                <mat-form-field *ngIf="control.displayInput" appearance="outline" class="w-100">
-                  <input matInput placeholder="{{control.placeholder}}"
-                         formControlName="{{control?.name}}"
-                         type="{{control?.type}}" class="form-control" [readOnly]="readOnly"/>
-                  <mat-icon matPrefix class="op-5">
-                    <i-tabler name="user" class="icon-20 d-flex"></i-tabler>
-                  </mat-icon>
-
-                  <!-- Display the error message -->
-                  <mat-hint *ngIf="dynamicFormGroup.get(control.name)?.invalid"
-                            class="m-b-16 error-msg">
-                    <div class="text-error">
-                      {{ getErrorMessage(control) }}
-                    </div>
-                  </mat-hint>
-                </mat-form-field>
-              </div>
-
-              <!-- Display map input -->
-              <div class="col-sm-12" *ngIf="['map'].includes(control.type)">
-                <mat-form-field appearance="outline" class="w-100">
-                  <mat-label>Search for a place...</mat-label>
-                  <mat-icon matPrefix class="op-5">
-                    <i-tabler name="map-pin" class="icon-20 d-flex"></i-tabler>
-                  </mat-icon>
-
-                  <input #search matInput
-                         [placeholder]="control.placeholder || 'Search for a place...'"
-                         formControlName="{{control?.name}}"
-                         type="text">
-
-                  <div *ngIf="placeName" class="place-info-display">
-                    <h3>{{ placeName }}</h3>
-                    <p>{{ placeAddress }}</p>
-                  </div>
-
-                  <mat-hint *ngIf="dynamicFormGroup.get(control.name)?.invalid"
-                            class="m-b-16 error-msg">
-                    <div class="text-error">
-                      {{ getErrorMessage(control) }}
-                    </div>
-                  </mat-hint>
-                </mat-form-field>
-
-                <google-map
-                  height="500px"
-                  width="100%"
-                  [zoom]="zoom"
-                  [center]="center"
-                  [options]="options"
-                >
-                  <map-marker
-                    *ngIf="markerPosition"
-                    [position]="markerPosition"
-                    [options]="markerOptions"
-                    (mapDragend)="markerDragged($event)"
-                    #placeMarker
-                  >
-                  </map-marker>
-                  <map-info-window>
-                    <div *ngIf="placeName">
-                      <h3>{{ placeName }}</h3>
-                      <p>{{ placeAddress }}</p>
-                    </div>
-                  </map-info-window>
-                </google-map>
-              </div>
-              <!-- Display dropdown (select) -->
-              <div class="col-sm-12" *ngIf="control.type === 'select'">
-                <mat-form-field appearance="outline" class="w-100">
-                  <mat-select formControlName="{{control?.name}}"
-                              placeholder="{{control.placeholder}}">
-                    <mat-option *ngFor="let option of control.options" [value]="option.value">
-                      {{ option.label }}
-                    </mat-option>
-                  </mat-select>
-
-                  <!-- Display the error message -->
-                  <mat-hint *ngIf="dynamicFormGroup.get(control.name)?.invalid"
-                            class="m-b-16 error-msg">
-                    <div class="text-error">
-                      {{ getErrorMessage(control) }}
-                    </div>
-                  </mat-hint>
-                </mat-form-field>
-              </div>
-
-              <!-- Display date and time input -->
-              <div class="col-sm-12" *ngIf="control.type === 'datetime-local'">
-                <mat-form-field appearance="outline" class="w-100">
-                  <input matInput placeholder="{{control.placeholder}}"
-                         formControlName="{{control?.name}}"
-                         type="datetime-local" class="form-control"
-                         (focus)="setBrowserTime(control.name)"/>
-                  <mat-icon matPrefix class="op-5">
-                    <i-tabler name="clock" class="icon-20 d-flex"></i-tabler>
-                  </mat-icon>
-
-                  <!-- Display the error message -->
-                  <mat-hint *ngIf="dynamicFormGroup.get(control.name)?.invalid"
-                            class="m-b-16 error-msg">
-                    <div class="text-error">
-                      {{ getErrorMessage(control) }}
-                    </div>
-                  </mat-hint>
-                </mat-form-field>
-              </div>
-
-              <!-- Display file upload input -->
-              <div class="col-sm-12" *ngIf="control.type === 'file'">
                 <div class="file-upload-container">
-                  <label>{{ control.label }}</label>
                   <input type="file" accept=".jpeg,.jpg,.png"
                          (change)="onFileSelected($event, control.name)"
                          class="form-control"/>
-                  <mat-icon class="op-5">
-                    <i-tabler name="upload" class="icon-20 d-flex"></i-tabler>
-                  </mat-icon>
                 </div>
 
-                <!-- Display the error message -->
+                <!-- Upload progress bar -->
+                <mat-progress-bar
+                  *ngIf="uploadProgress[control.name] !== undefined"
+                  mode="determinate"
+                  [value]="uploadProgress[control.name]"
+                  class="m-t-8">
+                </mat-progress-bar>
+
                 <mat-hint
                   *ngIf="dynamicFormGroup.get(control.name)?.invalid && dynamicFormGroup.get(control.name)?.touched"
                   class="m-b-16 error-msg">
-                  <div class="text-error">
-                    {{ getErrorMessage(control) }}
-                  </div>
+                  <div class="text-error">{{ getErrorMessage(control) }}</div>
                 </mat-hint>
               </div>
+            </ng-container>
 
-            </div>
+            <!-- All other fields -->
+            <ng-container *ngFor="let control of form.formControls">
+              <div *ngIf="control.type !== 'file'" class="row">
+
+                <!-- Label for text/email/password/number/date/select/map fields -->
+                <div *ngIf="['text', 'email', 'password', 'number', 'date', 'select', 'map'].includes(control.type)
+                && control.displayInput !== false" [class]="control?.class">
+                  <mat-label class="mat-subtitle-2 f-w-600 d-block m-b-16">
+                    {{ control.label }}
+                  </mat-label>
+                </div>
+
+                <!-- Date input -->
+                <div class="col-sm-12" *ngIf="control.type === 'date'">
+                  <mat-form-field appearance="outline" class="w-100">
+                    <input matInput [matDatepicker]="birthpicker"
+                           placeholder="{{control.placeholder}}"
+                           formControlName="{{control?.name}}"/>
+                    <mat-datepicker-toggle matIconSuffix [for]="birthpicker"></mat-datepicker-toggle>
+                    <mat-datepicker #birthpicker></mat-datepicker>
+                  </mat-form-field>
+                </div>
+
+                <!-- Text / email / password / number input -->
+                <div class="col-sm-12"
+                     *ngIf="['text', 'email', 'password', 'number'].includes(control.type)">
+                  <mat-form-field *ngIf="control.displayInput !== false" appearance="outline" class="w-100">
+                    <input matInput placeholder="{{control.placeholder}}"
+                           formControlName="{{control?.name}}"
+                           type="{{control?.type}}" class="form-control" [readOnly]="readOnly"/>
+                    <mat-icon matPrefix class="op-5">
+                      <i-tabler name="user" class="icon-20 d-flex"></i-tabler>
+                    </mat-icon>
+                    <mat-hint *ngIf="dynamicFormGroup.get(control.name)?.invalid"
+                              class="m-b-16 error-msg">
+                      <div class="text-error">{{ getErrorMessage(control) }}</div>
+                    </mat-hint>
+                  </mat-form-field>
+                </div>
+
+                <!-- Map input -->
+                <div class="col-sm-12" *ngIf="control.type === 'map'">
+                  <mat-form-field appearance="outline" class="w-100">
+                    <mat-label>Search for a place...</mat-label>
+                    <mat-icon matPrefix class="op-5">
+                      <i-tabler name="map-pin" class="icon-20 d-flex"></i-tabler>
+                    </mat-icon>
+                    <input #search matInput
+                           [placeholder]="control.placeholder || 'Search for a place...'"
+                           formControlName="{{control?.name}}"
+                           type="text">
+                    <div *ngIf="placeName" class="place-info-display">
+                      <h3>{{ placeName }}</h3>
+                      <p>{{ placeAddress }}</p>
+                    </div>
+                    <mat-hint *ngIf="dynamicFormGroup.get(control.name)?.invalid"
+                              class="m-b-16 error-msg">
+                      <div class="text-error">{{ getErrorMessage(control) }}</div>
+                    </mat-hint>
+                  </mat-form-field>
+
+                  <google-map height="500px" width="100%" [zoom]="zoom" [center]="center" [options]="options">
+                    <map-marker
+                      *ngIf="markerPosition"
+                      [position]="markerPosition"
+                      [options]="markerOptions"
+                      (mapDragend)="markerDragged($event)"
+                      #placeMarker>
+                    </map-marker>
+                    <map-info-window>
+                      <div *ngIf="placeName">
+                        <h3>{{ placeName }}</h3>
+                        <p>{{ placeAddress }}</p>
+                      </div>
+                    </map-info-window>
+                  </google-map>
+                </div>
+
+                <!-- Select / dropdown -->
+                <div class="col-sm-12" *ngIf="control.type === 'select'">
+                  <mat-form-field appearance="outline" class="w-100">
+                    <mat-select formControlName="{{control?.name}}"
+                                placeholder="{{control.placeholder}}">
+                      <mat-option *ngFor="let option of control.options" [value]="option.value">
+                        {{ option.label }}
+                      </mat-option>
+                    </mat-select>
+                    <mat-hint *ngIf="dynamicFormGroup.get(control.name)?.invalid"
+                              class="m-b-16 error-msg">
+                      <div class="text-error">{{ getErrorMessage(control) }}</div>
+                    </mat-hint>
+                  </mat-form-field>
+                </div>
+
+                <!-- Date-time input -->
+                <div class="col-sm-12" *ngIf="control.type === 'datetime-local'">
+                  <mat-form-field appearance="outline" class="w-100">
+                    <input matInput placeholder="{{control.placeholder}}"
+                           formControlName="{{control?.name}}"
+                           type="datetime-local" class="form-control"
+                           (focus)="setBrowserTime(control.name)"/>
+                    <mat-icon matPrefix class="op-5">
+                      <i-tabler name="clock" class="icon-20 d-flex"></i-tabler>
+                    </mat-icon>
+                    <mat-hint *ngIf="dynamicFormGroup.get(control.name)?.invalid"
+                              class="m-b-16 error-msg">
+                      <div class="text-error">{{ getErrorMessage(control) }}</div>
+                    </mat-hint>
+                  </mat-form-field>
+                </div>
+
+              </div>
+            </ng-container>
+
           </div>
         </div>
 
         <div class="row justify-content-end">
           <div class="col-sm-12">
-            <button (click)="onSubmit()" type="button" mat-flat-button
-                    color="primary">{{ form.saveBtnTitle }}
+            <button (click)="onSubmit()" type="button" mat-flat-button color="primary">
+              {{ form.saveBtnTitle }}
             </button>
-            <button (click)="resetForm()" type="button" mat-flat-button color="warn"
-                    class="m-l-8">{{ form.resetBtnTitle }}
+            <button (click)="onCancel.emit()" type="button" mat-flat-button color="warn" class="m-l-8">
+              {{ form.resetBtnTitle }}
             </button>
           </div>
         </div>
+
       </form>
     </mat-card-content>
   </mat-card>

--- a/src/app/pages/apps/reusable/dynamic-form/dynamic-form.component.ts
+++ b/src/app/pages/apps/reusable/dynamic-form/dynamic-form.component.ts
@@ -12,6 +12,8 @@ import {IForm} from "../../forms/interfaces/IForm";
 import {AbstractControl, FormBuilder, FormGroup, ValidatorFn, Validators} from "@angular/forms";
 import {FormControls} from "../../forms/interfaces/form-controls";
 import {GoogleMap, MapInfoWindow, MapMarker} from "@angular/google-maps";
+import {HttpEventType} from "@angular/common/http";
+import {UploadService} from "../../../../services/upload.service";
 
 @Component({
   selector: 'app-dynamic-form',
@@ -20,6 +22,7 @@ import {GoogleMap, MapInfoWindow, MapMarker} from "@angular/google-maps";
 })
 export class DynamicFormComponent implements OnInit {
   @Output() onCreationValue = new EventEmitter<any>();
+  @Output() onCancel = new EventEmitter<void>();
   @Input() form!: IForm;
   @Input() readOnly: boolean = false;  // Uncommented and properly declared
   dynamicFormGroup: FormGroup;
@@ -48,9 +51,15 @@ export class DynamicFormComponent implements OnInit {
 
   private autocomplete!: google.maps.places.Autocomplete;
 
+  uploadProgress: { [controlName: string]: number } = {};
+
   // ================
 
-  constructor(private fb: FormBuilder, private ngZone: NgZone) {
+  constructor(
+    private fb: FormBuilder,
+    private ngZone: NgZone,
+    private uploadService: UploadService
+  ) {
     this.dynamicFormGroup = fb.group({}, {updateOn: 'submit'});
   }
 
@@ -106,24 +115,40 @@ export class DynamicFormComponent implements OnInit {
 
   onFileSelected(event: Event, controlName: string) {
     const fileInput = event.target as HTMLInputElement;
-    if (fileInput.files && fileInput.files.length > 0) {
-      const file = fileInput.files[0];
-      const validTypes = ['image/jpeg', 'image/jpg', 'image/png'];
+    if (!fileInput.files || fileInput.files.length === 0) return;
 
-      if (!validTypes.includes(file.type)) {
-        alert('Please upload a valid image file (JPEG, JPG, PNG)');
-        return;
-      }
+    const file = fileInput.files[0];
+    const validTypes = ['image/jpeg', 'image/jpg', 'image/png'];
 
-      const maxSizeInMB = 5;
-      if (file.size > maxSizeInMB * 1024 * 1024) {
-        alert(`File size must not exceed ${maxSizeInMB} MB`);
-        return;
-      }
-
-      this.dynamicFormGroup.get(controlName)?.setValue(file.name);
-      console.log('Selected file:', file.name);
+    if (!validTypes.includes(file.type)) {
+      alert('Please upload a valid image file (JPEG, JPG, PNG)');
+      return;
     }
+
+    if (file.size > 10 * 1024 * 1024) {
+      alert('File size must not exceed 10 MB');
+      return;
+    }
+
+    this.uploadProgress[controlName] = 0;
+    this.dynamicFormGroup.get(controlName)?.setValue('');
+
+    this.uploadService.upload(file).subscribe({
+      next: (event) => {
+        if (event.type === HttpEventType.UploadProgress && event.total) {
+          this.uploadProgress[controlName] = Math.round(100 * event.loaded / event.total);
+        } else if (event.type === HttpEventType.Response) {
+          const url = (event.body as any)?.url;
+          this.dynamicFormGroup.get(controlName)?.setValue(url);
+          delete this.uploadProgress[controlName];
+        }
+      },
+      error: (err) => {
+        delete this.uploadProgress[controlName];
+        alert('Upload failed. Please try again.');
+        console.error('Upload error:', err);
+      }
+    });
   }
 
   minAgeValidator(minAge: number): ValidatorFn {

--- a/src/app/pages/apps/reusable/dynamic-form/dynamic-form.component.ts
+++ b/src/app/pages/apps/reusable/dynamic-form/dynamic-form.component.ts
@@ -12,8 +12,9 @@ import {IForm} from "../../forms/interfaces/IForm";
 import {AbstractControl, FormBuilder, FormGroup, ValidatorFn, Validators} from "@angular/forms";
 import {FormControls} from "../../forms/interfaces/form-controls";
 import {GoogleMap, MapInfoWindow, MapMarker} from "@angular/google-maps";
-import {HttpEventType} from "@angular/common/http";
+import {HttpClient, HttpEventType} from "@angular/common/http";
 import {UploadService} from "../../../../services/upload.service";
+import {environment} from "../../../../../../environment";
 
 @Component({
   selector: 'app-dynamic-form',
@@ -58,7 +59,8 @@ export class DynamicFormComponent implements OnInit {
   constructor(
     private fb: FormBuilder,
     private ngZone: NgZone,
-    private uploadService: UploadService
+    private uploadService: UploadService,
+    private http: HttpClient
   ) {
     this.dynamicFormGroup = fb.group({}, {updateOn: 'submit'});
   }
@@ -93,12 +95,35 @@ export class DynamicFormComponent implements OnInit {
       this.dynamicFormGroup = this.fb.group(formGroup);
     }
     this.center = {lat: -1.286389, lng: 36.817223};
+
+    // Fetch options for any relation select fields
+    this.form.formControls
+      .filter(c => c.apiEndpoint)
+      .forEach(control => {
+        this.http.get<any[]>(environment.apiUrl + control.apiEndpoint + '?page=0&size=100')
+          .subscribe(items => {
+            control.options = items.map(item => ({
+              label: item[control.optionLabel!],
+              value: item[control.optionValue!]
+            }));
+          });
+      });
   }
 
   onSubmit() {
     if (this.dynamicFormGroup.valid) {
-      console.log('Form values:', this.dynamicFormGroup.value);
-      const formValues = this.dynamicFormGroup.value;
+      const raw = this.dynamicFormGroup.value;
+      const formValues: any = {};
+
+      this.form.formControls.forEach(control => {
+        const val = raw[control.name];
+        if (control.isRelation && val !== null && val !== undefined && val !== '') {
+          formValues[control.name] = { id: val };
+        } else {
+          formValues[control.name] = val;
+        }
+      });
+
       this.onCreationValue.emit(formValues);
     }
   }

--- a/src/app/pages/apps/school-stuff/school-stuff.component.ts
+++ b/src/app/pages/apps/school-stuff/school-stuff.component.ts
@@ -128,5 +128,6 @@ export class SchoolStuffComponent extends CrudActions implements OnInit {
     });
   }
 
-}
 
+  protected override onSuccess(): void { this.getRecords(); }
+}

--- a/src/app/pages/apps/schools/school-view/school-view.component.html
+++ b/src/app/pages/apps/schools/school-view/school-view.component.html
@@ -7,7 +7,8 @@
   <app-dynamic-form
     [form]="formInput"
     [readOnly]="readOnly"
-    (onCreationValue)="onCreationValue($event)">
+    (onCreationValue)="onCreationValue($event)"
+    (onCancel)="closeDialog()">
   </app-dynamic-form>
 
   <div *ngIf="local_data.errorMessage" class="error-message text-danger">

--- a/src/app/pages/apps/schools/schools.component.ts
+++ b/src/app/pages/apps/schools/schools.component.ts
@@ -110,5 +110,6 @@ export class SchoolsComponent extends CrudActions implements OnInit {
     });
   }
 
-}
 
+  protected override onSuccess(): void { this.getRecords(); }
+}

--- a/src/app/pages/apps/students/students.component.ts
+++ b/src/app/pages/apps/students/students.component.ts
@@ -175,6 +175,6 @@ export class StudentsComponent extends CrudActions implements OnInit {
     });
   }
 
+
+  protected override onSuccess(): void { this.getRecords(); }
 }
-
-

--- a/src/app/pages/apps/terminals/terminals.component.ts
+++ b/src/app/pages/apps/terminals/terminals.component.ts
@@ -115,5 +115,6 @@ export class TerminalsComponent extends CrudActions implements OnInit {
     this.router.navigate(['apps/terminals', id]);
   }
 
-}
 
+  protected override onSuccess(): void { this.getRecords(); }
+}

--- a/src/app/pages/apps/trips/trips.component.ts
+++ b/src/app/pages/apps/trips/trips.component.ts
@@ -126,5 +126,6 @@ export class TripsComponent extends CrudActions implements OnInit {
     });
   }
 
-}
 
+  protected override onSuccess(): void { this.getRecords(); }
+}

--- a/src/app/pages/apps/vehicles/vehicles.component.ts
+++ b/src/app/pages/apps/vehicles/vehicles.component.ts
@@ -123,6 +123,6 @@ export class VehiclesComponent extends CrudActions implements OnInit {
     });
   }
 
+
+  protected override onSuccess(): void { this.getRecords(); }
 }
-
-

--- a/src/app/services/upload.service.ts
+++ b/src/app/services/upload.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpEvent, HttpHeaders } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environment';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UploadService {
+
+  constructor(private http: HttpClient) {}
+
+  upload(file: File): Observable<HttpEvent<{ url: string }>> {
+    const formData = new FormData();
+    formData.append('file', file);
+
+    const headers = new HttpHeaders({
+      Authorization: 'Bearer ' + localStorage.getItem('token')
+    });
+
+    return this.http.post<{ url: string }>(
+      environment.apiUrl + 'files/upload',
+      formData,
+      { headers, reportProgress: true, observe: 'events' }
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- **Dynamic parent selectors** — child entity forms (school, fleet, driver, student, staff, billing, trip) now load parent options from the API at runtime via `apiEndpoint`/`optionLabel`/`optionValue` fields on `FormControls`
- **Relation wrapping** — `DynamicFormComponent` wraps selected relation values as `{ id }` objects before emitting, matching what the JHipster API expects
- **View/Update pre-population** — `CrudActions.prepareFormWithData` extracts the `.id` from nested relation objects so the correct parent is pre-selected when viewing or updating a record
- **Post-CRUD table refresh** — `onSuccess()` hook added to `CrudActions`, overridden in all 10 entity components to reload the table after add/update/delete without a full page reload
- **New form config** — `student-billings-form-config.ts` added

## Test Plan

- [ ] Open Add School → Organization dropdown populates from API, cancel closes modal
- [ ] Open Add Fleet → School and Terminal dropdowns populate, save creates record
- [ ] Open Update School → Organization pre-selected correctly, change and save works
- [ ] Create any child record → parent table row appears immediately without page reload
- [ ] Repeat for Driver (fleet), Student (fleet + guardian), Staff (school), Billing (student), Trip (driver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)