### PR TITLE
feat: map selector for schools and terminals with live tracking fix

### DIFF
--- a/src/app/pages/apps/forms/interfaces/form-controls.ts
+++ b/src/app/pages/apps/forms/interfaces/form-controls.ts
@@ -15,4 +15,6 @@ export interface FormControls {
   optionLabel?: string;
   optionValue?: string;
   isRelation?: boolean;
+  latitudeField?: string;
+  longitudeField?: string;
 }

--- a/src/app/pages/apps/forms/school-registration-form-config.ts
+++ b/src/app/pages/apps/forms/school-registration-form-config.ts
@@ -37,21 +37,38 @@ export const schoolForm: IForm = {
       "name": "location",
       "label": "Location",
       "value": "",
-      "placeholder": "e.g Lavington, Nairobi",
-      "class": "col-md-6",
-      "type": "text",
+      "placeholder": "Search for school location...",
+      "class": "col-sm-12",
+      "type": "map",
+      "latitudeField": "latitude",
+      "longitudeField": "longitude",
       "validators": [
-        {
-          "validatorName": "pattern",
-          "pattern": "^[a-zA-Z\\s]+$",
-          "message": "Location should have only alphabet characters"
-        },
         {
           "validatorName": "required",
           "pattern": "",
           "message": "Location is Required"
         }
       ]
+    },
+    {
+      "name": "latitude",
+      "label": "Latitude",
+      "value": "",
+      "placeholder": "",
+      "class": "col-md-6",
+      "type": "text",
+      "displayInput": false,
+      "validators": []
+    },
+    {
+      "name": "longitude",
+      "label": "Longitude",
+      "value": "",
+      "placeholder": "",
+      "class": "col-md-6",
+      "type": "text",
+      "displayInput": false,
+      "validators": []
     },
     {
       "name": "phoneNumber",

--- a/src/app/pages/apps/forms/student-registration-form-config.ts
+++ b/src/app/pages/apps/forms/student-registration-form-config.ts
@@ -141,6 +141,8 @@ export const studentForm: IForm = {
       "class": "col-md-6",
       "type": "map",
       "displayInput": true,
+      "latitudeField": "latitude",
+      "longitudeField": "longitude",
       "validators": [
         {
           "validatorName": "pattern",

--- a/src/app/pages/apps/forms/terminals-form-config.ts
+++ b/src/app/pages/apps/forms/terminals-form-config.ts
@@ -100,6 +100,48 @@ export const terminalForm: IForm = {
           "message": "Status is Required"
         }
       ]
+    },
+    {
+      "name": "terminalLocation",
+      "label": "Installation Location",
+      "value": "",
+      "placeholder": "Search for terminal installation location...",
+      "class": "col-sm-12",
+      "type": "map",
+      "displayInput": true,
+      "latitudeField": "latitude",
+      "longitudeField": "longitude",
+      "validators": []
+    },
+    {
+      "name": "latitude",
+      "label": "Latitude",
+      "value": "",
+      "placeholder": "",
+      "class": "col-md-6",
+      "type": "text",
+      "displayInput": false,
+      "validators": []
+    },
+    {
+      "name": "longitude",
+      "label": "Longitude",
+      "value": "",
+      "placeholder": "",
+      "class": "col-md-6",
+      "type": "text",
+      "displayInput": false,
+      "validators": []
     }
   ]
+}
+
+export const terminalUpdateForm: IForm = {
+  formTitle: 'Terminal',
+  saveBtnTitle: 'Save Terminal',
+  resetBtnTitle: 'Cancel',
+  displayColumns: terminalForm.displayColumns,
+  formControls: terminalForm.formControls.filter(
+    c => !['terminalLocation', 'latitude', 'longitude'].includes(c.name)
+  )
 }

--- a/src/app/pages/apps/reusable/dynamic-form/dynamic-form.component.ts
+++ b/src/app/pages/apps/reusable/dynamic-form/dynamic-form.component.ts
@@ -45,7 +45,9 @@ export class DynamicFormComponent implements OnInit {
     maxZoom: 18,
     minZoom: 8,
   };
-  markerOptions: google.maps.MarkerOptions = {draggable: false};
+  get markerOptions(): google.maps.MarkerOptions {
+    return { draggable: !this.readOnly };
+  }
   markerPosition!: google.maps.LatLngLiteral;
   placeName: string = '';
   placeAddress: string = '';
@@ -95,6 +97,17 @@ export class DynamicFormComponent implements OnInit {
       this.dynamicFormGroup = this.fb.group(formGroup);
     }
     this.center = {lat: -1.286389, lng: 36.817223};
+
+    // Bug 2 fix: pre-populate map center/marker from stored lat/lng on View/Update
+    const mapCtrl = this.form.formControls.find(c => c.type === 'map');
+    if (mapCtrl?.latitudeField && mapCtrl?.longitudeField) {
+      const lat = parseFloat(this.dynamicFormGroup.get(mapCtrl.latitudeField)?.value);
+      const lng = parseFloat(this.dynamicFormGroup.get(mapCtrl.longitudeField)?.value);
+      if (!isNaN(lat) && !isNaN(lng)) {
+        this.center = { lat, lng };
+        this.markerPosition = { lat, lng };
+      }
+    }
 
     // Fetch options for any relation select fields
     this.form.formControls
@@ -253,11 +266,15 @@ export class DynamicFormComponent implements OnInit {
             this.placeName = place.name || '';
             this.placeAddress = place.formatted_address || '';
 
-            this.center = {
-              lat: place.geometry.location.lat(),
-              lng: place.geometry.location.lng(),
-            };
+            const lat = place.geometry.location.lat();
+            const lng = place.geometry.location.lng();
+            this.center = { lat, lng };
             this.markerPosition = this.center;
+
+            // Bug 1 fix: write coordinates into the form controls
+            const mapCtrl = this.form.formControls.find(c => c.type === 'map');
+            if (mapCtrl?.latitudeField)  this.dynamicFormGroup.get(mapCtrl.latitudeField)?.setValue(lat.toString());
+            if (mapCtrl?.longitudeField) this.dynamicFormGroup.get(mapCtrl.longitudeField)?.setValue(lng.toString());
 
             if (place.geometry.viewport) {
               this.map.fitBounds(place.geometry.viewport);
@@ -285,11 +302,14 @@ export class DynamicFormComponent implements OnInit {
   // **THE FIX IS HERE:** Change type from google.maps.MouseEvent to google.maps.MapMouseEvent
   markerDragged(event: google.maps.MapMouseEvent) {
     if (event.latLng) {
-      this.markerPosition = {
-        lat: event.latLng.lat(),
-        lng: event.latLng.lng(),
-      };
-      // ... (optional: reverse geocode the new position if you want to update placeName/Address after drag)
+      const lat = event.latLng.lat();
+      const lng = event.latLng.lng();
+      this.markerPosition = { lat, lng };
+
+      // Bug 1 fix: keep form controls in sync when marker is dragged
+      const mapCtrl = this.form.formControls.find(c => c.type === 'map');
+      if (mapCtrl?.latitudeField)  this.dynamicFormGroup.get(mapCtrl.latitudeField)?.setValue(lat.toString());
+      if (mapCtrl?.longitudeField) this.dynamicFormGroup.get(mapCtrl.longitudeField)?.setValue(lng.toString());
     }
   }
 }

--- a/src/app/pages/apps/terminals/terminal-view/terminal-view.component.ts
+++ b/src/app/pages/apps/terminals/terminal-view/terminal-view.component.ts
@@ -14,10 +14,10 @@ export class TerminalViewComponent implements AfterViewInit, OnInit {
   terminalId: any;
   map: any;
   marker: any;
-  studentMarker: any;
 
   terminal: any;
   vehicle: any;
+  driver: any;
 
   hide = true;
   hide2 = true;
@@ -59,8 +59,6 @@ export class TerminalViewComponent implements AfterViewInit, OnInit {
 
   ngAfterViewInit() {
     L.Icon.Default.imagePath = 'assets/images/maps/';
-    // this.fetchVehicleInfo(this.terminalId);
-    // this.initMap();
   }
 
   /**
@@ -68,6 +66,7 @@ export class TerminalViewComponent implements AfterViewInit, OnInit {
    * @private
    */
   private initMap() {
+    if (this.map) return; // prevent re-initialization from the polling interval
     const busIcon = L.icon({
       iconUrl: 'assets/images/maps/school_bus.png',  // Path to your bus icon
       iconSize: [32, 32],  // Size of the icon
@@ -76,43 +75,19 @@ export class TerminalViewComponent implements AfterViewInit, OnInit {
     });
     console.log("Loading map with data: {}", this.terminal);
 
-    this.map = L.map('map').setView([Number(this.terminal.latitude), Number(this.terminal.longitude)], 15); // Set initial coordinates and zoom level
-
-    const getMarkers = (): L.Marker[] => {
-      return [
-        new L.Marker(new L.LatLng(43.5121264, 16.4700729), {
-          icon: new L.Icon({
-            iconSize: [50, 41],
-            iconAnchor: [13, 41],
-            iconUrl: 'assets/blue-marker.svg',
-          }),
-          title: 'Workspace'
-        } as L.MarkerOptions),
-        new L.Marker(new L.LatLng(43.5074826, 16.4390046), {
-          icon: new L.Icon({
-            iconSize: [50, 41],
-            iconAnchor: [13, 41],
-            iconUrl: 'assets/red-marker.svg',
-          }),
-          title: 'Riva'
-        } as L.MarkerOptions),
-      ] as L.Marker[];
-    };
+    this.map = L.map('map').setView([Number(this.terminal.latitude), Number(this.terminal.longitude)], 15);
 
     L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
       attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
     }).addTo(this.map);
 
-    this.marker = L.marker([Number(this.terminal.latitude), Number(this.terminal.longitude)], {icon: busIcon}).addTo(this.map)
-    .bindPopup("Driver: John Mwangi.<br>Vehicle: KDH 722E")
-    .openPopup();
+    const driverName = this.driver?.name ?? 'Unknown Driver';
+    const numberPlate = this.vehicle?.numberPlate ?? 'Unknown Vehicle';
 
-    this.studentMarker = L.marker([Number(-1.2509837), Number(36.783291)], {icon: busIcon}).addTo(this.map)
-    .bindPopup("Driver: John Mwangi.<br>Vehicle: KDH 722E")
-    .openPopup();
-    L.polyline([L.latLng(this.terminal.latitude, this.terminal.longitude),
-      L.latLng(-1.2509837, 36.783291)], {color: '#0d9148'})
-    .addTo(this.map);
+    this.marker = L.marker([Number(this.terminal.latitude), Number(this.terminal.longitude)], {icon: busIcon})
+      .addTo(this.map)
+      .bindPopup(`Driver: ${driverName}<br>Vehicle: ${numberPlate}`)
+      .openPopup();
 
     // Set up the interval to refresh the map every 5 seconds
     setInterval(() => {
@@ -149,7 +124,20 @@ export class TerminalViewComponent implements AfterViewInit, OnInit {
     .subscribe((res: any) => {
       console.log("Getting vehicle information: {}", res)
       this.vehicle = res[0];
-      //this.initMap();
+      if (this.vehicle?.id) {
+        this.fetchDriverInfo(this.vehicle.id);
+      } else {
+        this.initMap();
+      }
+    })
+  }
+
+  fetchDriverInfo(fleetId: number) {
+    this.http.get(environment.apiUrl.concat("drivers?fleetId.equals=" + fleetId))
+    .subscribe((res: any) => {
+      console.log("Getting driver information: {}", res)
+      this.driver = res[0];
+      this.initMap();
     })
   }
 

--- a/src/app/pages/apps/terminals/terminals.component.ts
+++ b/src/app/pages/apps/terminals/terminals.component.ts
@@ -4,7 +4,7 @@ import { HttpClient } from "@angular/common/http";
 import {CrudActions} from "../reusable/CrudActions";
 import {IForm} from "../forms/interfaces/IForm";
 import {EntityAction} from "../reusable/EntityAction";
-import {terminalForm} from "../forms/terminals-form-config";
+import {terminalForm, terminalUpdateForm} from "../forms/terminals-form-config";
 import {Router} from "@angular/router";
 
 @Component({
@@ -80,7 +80,7 @@ export class TerminalsComponent extends CrudActions implements OnInit {
       id: record.id,
       data: record
     };
-    this.onUpdateRecord(entity, this.recordForm);
+    this.onUpdateRecord(entity, terminalUpdateForm as IForm);
   }
 
   /**


### PR DESCRIPTION
## Summary

- **Map selector for Schools** — `location` field upgraded from plain text to a Google Places map picker; hidden `latitude`/`longitude` fields are populated on place select or marker drag
- **Map selector for Terminals (create only)** — new `terminalLocation` map field + hidden lat/lng on the create form; update form excludes these fields since the device process owns live location
- **Student map wired up** — `homeAddress` map control now has `latitudeField`/`longitudeField` pointers so the bug fixes below apply

## Bug fixes

| # | Bug | Fix |
|---|-----|-----|
| 1 | Coordinates silently dropped — `DynamicFormComponent` never called `setValue` on lat/lng controls after place select or marker drag | `setValue` called in `place_changed` listener and `markerDragged` |
| 2 | Map always opened on default Nairobi center on View/Update, ignoring stored coordinates | `ngOnInit` now reads lat/lng form values and sets `center`/`markerPosition` before the map renders |
| 3 | Marker was never draggable | `markerOptions` is now a getter returning `{ draggable: !this.readOnly }` |
| 4 | `TerminalViewComponent` — `initMap()` was fully implemented but never called | Data chain: `fetchTerminalInfo` → `fetchVehicleInfo` → `fetchDriverInfo` → `initMap()` |
| 5 | Terminal view showed two bus icons and hardcoded driver info | Removed second marker, polyline, and dead `getMarkers()`; popup now shows real driver name and number plate |

## Test Plan

- [ ] Create School → location field shows map, pick a place, verify lat/lng in network payload
- [ ] View/Update School with existing lat/lng → map opens centred on stored location, not Nairobi default
- [ ] Update School → drag marker, save, verify new coordinates persisted
- [ ] Create Terminal → map picker appears, lat/lng in payload
- [ ] Update Terminal → no map fields shown
- [ ] View Terminal → navigates to live tracking, single bus icon, correct driver + plate in popup
- [ ] Create/View/Update Student → homeAddress map still works, coordinates save correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)