### PR TITLE
feat: server-side pagination, camelCase column headers, and title-case save

### DIFF
--- a/src/app/pages/apps/apps.module.ts
+++ b/src/app/pages/apps/apps.module.ts
@@ -49,6 +49,7 @@ import { OrganizationsComponent } from './organizations/organizations.component'
 import {DynamicFormComponent} from "./reusable/dynamic-form/dynamic-form.component";
 import {TripViewerComponent} from "./trips/trip-viewer/trip-viewer.component";
 import {GoogleMapsModule} from "@angular/google-maps";
+import {CamelToTitlePipe} from "../../pipe/camel-to-title.pipe";
 
 @NgModule({ exports: [TablerIconsModule],
     declarations: [
@@ -70,7 +71,8 @@ import {GoogleMapsModule} from "@angular/google-maps";
         StudentTripComponent,
         TerminalViewComponent,
         DialogBoxComponent,
-        DynamicFormComponent
+        DynamicFormComponent,
+        CamelToTitlePipe
     ], imports: [GoogleMapsModule,
         CommonModule,
         RouterModule.forChild(AppsRoutes),

--- a/src/app/pages/apps/drivers/drivers.component.html
+++ b/src/app/pages/apps/drivers/drivers.component.html
@@ -8,7 +8,9 @@
                      (onAddItem)="onAddItem($event)"
                      (onUpdateItem)="onUpdateItem($event)"
                      (onDeleteItem)="onDeleteItem($event)"
-></app-crud-data-table>
+  [totalRecords]="totalRecords"
+  (pageChange)="onPageChange($event)">
+</app-crud-data-table>
 
 
 

--- a/src/app/pages/apps/drivers/drivers.component.ts
+++ b/src/app/pages/apps/drivers/drivers.component.ts
@@ -19,6 +19,9 @@ export class DriversComponent extends CrudActions implements OnInit {
   displayedColumns: string[];
   tableHeading: string;
   tableData: any[];
+  totalRecords = 0;
+  currentPage = 0;
+  pageSize = 20;
   entityName: string = 'drivers';
 
   constructor(http: HttpClient, dialog: MatDialog) {
@@ -33,15 +36,22 @@ export class DriversComponent extends CrudActions implements OnInit {
   }
 
   // Fetch schools from the backend
-  getRecords() {
+  getRecords(page = this.currentPage, size = this.pageSize) {
     let entity: EntityAction = {
       name: this.entityName,
       id: '',
       data: ''
     };
-    this.getRecord(entity).subscribe((response) => {
-      this.tableData = response
+    this.getRecord(entity, page, size).subscribe(response => {
+      this.tableData = response.body;
+      this.totalRecords = Number(response.headers.get('X-Total-Count') ?? 0);
     });
+  }
+
+  onPageChange(event: { page: number; size: number }) {
+    this.currentPage = event.page;
+    this.pageSize = event.size;
+    this.getRecords(event.page, event.size);
   }
 
   /**

--- a/src/app/pages/apps/drivers/drivers.component.ts
+++ b/src/app/pages/apps/drivers/drivers.component.ts
@@ -118,13 +118,15 @@ export class DriversComponent extends CrudActions implements OnInit {
    * @param record
    */
   onFilterValue(record: any) {
+    this.currentPage = 0;
     let entity: EntityAction = {
       name: this.entityName,
       id: '',
       data: record
     };
-    this.onFilterRecord(entity).subscribe((response) => {
-      this.tableData = response
+    this.onFilterRecord(entity, 0, this.pageSize).subscribe(response => {
+      this.tableData = response.body;
+      this.totalRecords = Number(response.headers.get('X-Total-Count') ?? 0);
     });
   }
 

--- a/src/app/pages/apps/drivers/drivers.component.ts
+++ b/src/app/pages/apps/drivers/drivers.component.ts
@@ -21,7 +21,7 @@ export class DriversComponent extends CrudActions implements OnInit {
   tableData: any[];
   totalRecords = 0;
   currentPage = 0;
-  pageSize = 20;
+  pageSize = 10;
   entityName: string = 'drivers';
 
   constructor(http: HttpClient, dialog: MatDialog) {

--- a/src/app/pages/apps/guardians/guardians.component.html
+++ b/src/app/pages/apps/guardians/guardians.component.html
@@ -8,7 +8,9 @@
                      (onAddItem)="onAddItem($event)"
                      (onUpdateItem)="onUpdateItem($event)"
                      (onDeleteItem)="onDeleteItem($event)"
-></app-crud-data-table>
+  [totalRecords]="totalRecords"
+  (pageChange)="onPageChange($event)">
+</app-crud-data-table>
 
 
 

--- a/src/app/pages/apps/guardians/guardians.component.ts
+++ b/src/app/pages/apps/guardians/guardians.component.ts
@@ -38,7 +38,7 @@ export class GuardiansComponent extends CrudActions implements OnInit {
   tableData: any[];
   totalRecords = 0;
   currentPage = 0;
-  pageSize = 20;
+  pageSize = 10;
   entityName: string = 'guardians';
 
   constructor(http: HttpClient, dialog: MatDialog) {

--- a/src/app/pages/apps/guardians/guardians.component.ts
+++ b/src/app/pages/apps/guardians/guardians.component.ts
@@ -36,6 +36,9 @@ export class GuardiansComponent extends CrudActions implements OnInit {
   displayedColumns: string[];
   tableHeading: string;
   tableData: any[];
+  totalRecords = 0;
+  currentPage = 0;
+  pageSize = 20;
   entityName: string = 'guardians';
 
   constructor(http: HttpClient, dialog: MatDialog) {
@@ -50,15 +53,22 @@ export class GuardiansComponent extends CrudActions implements OnInit {
   }
 
   // Fetch schools from the backend
-  getRecords() {
+  getRecords(page = this.currentPage, size = this.pageSize) {
     let entity: EntityAction = {
       name: this.entityName,
       id: '',
       data: ''
     };
-    this.getRecord(entity).subscribe((response) => {
-      this.tableData = response
+    this.getRecord(entity, page, size).subscribe(response => {
+      this.tableData = response.body;
+      this.totalRecords = Number(response.headers.get('X-Total-Count') ?? 0);
     });
+  }
+
+  onPageChange(event: { page: number; size: number }) {
+    this.currentPage = event.page;
+    this.pageSize = event.size;
+    this.getRecords(event.page, event.size);
   }
 
   /**

--- a/src/app/pages/apps/guardians/guardians.component.ts
+++ b/src/app/pages/apps/guardians/guardians.component.ts
@@ -129,13 +129,15 @@ export class GuardiansComponent extends CrudActions implements OnInit {
    * @param record
    */
   onFilterValue(record: any) {
+    this.currentPage = 0;
     let entity: EntityAction = {
       name: this.entityName,
       id: '',
       data: record
     };
-    this.onFilterRecord(entity).subscribe((response) => {
-      this.tableData = response
+    this.onFilterRecord(entity, 0, this.pageSize).subscribe(response => {
+      this.tableData = response.body;
+      this.totalRecords = Number(response.headers.get('X-Total-Count') ?? 0);
     });
   }
 

--- a/src/app/pages/apps/invoices/invoices.component.html
+++ b/src/app/pages/apps/invoices/invoices.component.html
@@ -7,7 +7,9 @@
                      (onAddItem)="onAddItem($event)"
                      (onUpdateItem)="onUpdateItem($event)"
                      (onDeleteItem)="onDeleteItem($event)"
-></app-crud-data-table>
+  [totalRecords]="totalRecords"
+  (pageChange)="onPageChange($event)">
+</app-crud-data-table>
 
 
 

--- a/src/app/pages/apps/invoices/invoices.component.ts
+++ b/src/app/pages/apps/invoices/invoices.component.ts
@@ -91,7 +91,7 @@ export class InvoicesComponent extends CrudActions implements OnInit {
   tableData: any[];
   totalRecords = 0;
   currentPage = 0;
-  pageSize = 20;
+  pageSize = 10;
   entityName: string = 'student-billings';
 
   constructor(http: HttpClient, dialog: MatDialog) {

--- a/src/app/pages/apps/invoices/invoices.component.ts
+++ b/src/app/pages/apps/invoices/invoices.component.ts
@@ -182,13 +182,15 @@ export class InvoicesComponent extends CrudActions implements OnInit {
    * @param record
    */
   onFilterValue(record: any) {
+    this.currentPage = 0;
     let entity: EntityAction = {
       name: this.entityName,
       id: '',
       data: record
     };
-    this.onFilterRecord(entity).subscribe((response) => {
-      this.tableData = response
+    this.onFilterRecord(entity, 0, this.pageSize).subscribe(response => {
+      this.tableData = response.body;
+      this.totalRecords = Number(response.headers.get('X-Total-Count') ?? 0);
     });
   }
 

--- a/src/app/pages/apps/invoices/invoices.component.ts
+++ b/src/app/pages/apps/invoices/invoices.component.ts
@@ -89,6 +89,9 @@ export class InvoicesComponent extends CrudActions implements OnInit {
   displayedColumns: string[];
   tableHeading: string;
   tableData: any[];
+  totalRecords = 0;
+  currentPage = 0;
+  pageSize = 20;
   entityName: string = 'student-billings';
 
   constructor(http: HttpClient, dialog: MatDialog) {
@@ -103,15 +106,22 @@ export class InvoicesComponent extends CrudActions implements OnInit {
   }
 
   // Fetch schools from the backend
-  getRecords() {
+  getRecords(page = this.currentPage, size = this.pageSize) {
     let entity: EntityAction = {
       name: this.entityName,
       id: '',
       data: ''
     };
-    this.getRecord(entity).subscribe((response) => {
-      this.tableData = response
+    this.getRecord(entity, page, size).subscribe(response => {
+      this.tableData = response.body;
+      this.totalRecords = Number(response.headers.get('X-Total-Count') ?? 0);
     });
+  }
+
+  onPageChange(event: { page: number; size: number }) {
+    this.currentPage = event.page;
+    this.pageSize = event.size;
+    this.getRecords(event.page, event.size);
   }
 
   /**

--- a/src/app/pages/apps/organizations/organizations.component.html
+++ b/src/app/pages/apps/organizations/organizations.component.html
@@ -6,7 +6,9 @@
                      (onAddItem)="onAddItem($event)"
                      (onUpdateItem)="onUpdateItem($event)"
                      (onDeleteItem)="onDeleteItem($event)"
-></app-crud-data-table>
+  [totalRecords]="totalRecords"
+  (pageChange)="onPageChange($event)">
+</app-crud-data-table>
 
 
 

--- a/src/app/pages/apps/organizations/organizations.component.ts
+++ b/src/app/pages/apps/organizations/organizations.component.ts
@@ -19,7 +19,7 @@ export class OrganizationsComponent extends CrudActions implements OnInit {
   tableData: any[];
   totalRecords = 0;
   currentPage = 0;
-  pageSize = 20;
+  pageSize = 10;
   entityName: string = 'organizations';
 
   constructor(http: HttpClient, dialog: MatDialog) {

--- a/src/app/pages/apps/organizations/organizations.component.ts
+++ b/src/app/pages/apps/organizations/organizations.component.ts
@@ -17,6 +17,9 @@ export class OrganizationsComponent extends CrudActions implements OnInit {
   displayedColumns: string[];
   tableHeading: string;
   tableData: any[];
+  totalRecords = 0;
+  currentPage = 0;
+  pageSize = 20;
   entityName: string = 'organizations';
 
   constructor(http: HttpClient, dialog: MatDialog) {
@@ -31,15 +34,22 @@ export class OrganizationsComponent extends CrudActions implements OnInit {
   }
 
   // Fetch schools from the backend
-  getRecords() {
+  getRecords(page = this.currentPage, size = this.pageSize) {
     let entity: EntityAction = {
       name: this.entityName,
       id: '',
       data: ''
     };
-    this.getRecord(entity).subscribe((response) => {
-      this.tableData = response
+    this.getRecord(entity, page, size).subscribe(response => {
+      this.tableData = response.body;
+      this.totalRecords = Number(response.headers.get('X-Total-Count') ?? 0);
     });
+  }
+
+  onPageChange(event: { page: number; size: number }) {
+    this.currentPage = event.page;
+    this.pageSize = event.size;
+    this.getRecords(event.page, event.size);
   }
 
   /**

--- a/src/app/pages/apps/organizations/organizations.component.ts
+++ b/src/app/pages/apps/organizations/organizations.component.ts
@@ -110,13 +110,15 @@ export class OrganizationsComponent extends CrudActions implements OnInit {
    * @param record
    */
   onFilterValue(record: any) {
+    this.currentPage = 0;
     let entity: EntityAction = {
       name: this.entityName,
       id: '',
       data: record
     };
-    this.onFilterRecord(entity).subscribe((response) => {
-      this.tableData = response
+    this.onFilterRecord(entity, 0, this.pageSize).subscribe(response => {
+      this.tableData = response.body;
+      this.totalRecords = Number(response.headers.get('X-Total-Count') ?? 0);
     });
   }
 

--- a/src/app/pages/apps/reusable/CrudActions.ts
+++ b/src/app/pages/apps/reusable/CrudActions.ts
@@ -32,7 +32,7 @@ export class CrudActions {
    * Fetch records
    * @param entity
    */
-  getRecord(entity: EntityAction, page = 0, size = 20): Observable<HttpResponse<any>> {
+  getRecord(entity: EntityAction, page = 0, size = 10): Observable<HttpResponse<any>> {
     return this.http.get<any>(
       environment.apiUrl + entity.name + `?page=${page}&size=${size}`,
       { observe: 'response' }

--- a/src/app/pages/apps/reusable/CrudActions.ts
+++ b/src/app/pages/apps/reusable/CrudActions.ts
@@ -202,8 +202,11 @@ export class CrudActions {
    * Filter records given a name
    * @param record
    */
-  onFilterRecord(record: EntityAction): Observable<any> {
-    return this.http.get(environment.apiUrl.concat(record.name).concat("?name.contains=" + record.data));
+  onFilterRecord(record: EntityAction, page = 0, size = 10): Observable<HttpResponse<any>> {
+    return this.http.get<any>(
+      environment.apiUrl + record.name + `?name.contains=${record.data}&page=${page}&size=${size}`,
+      { observe: 'response' }
+    );
   }
 
 

--- a/src/app/pages/apps/reusable/CrudActions.ts
+++ b/src/app/pages/apps/reusable/CrudActions.ts
@@ -1,5 +1,5 @@
 import {MatDialog} from "@angular/material/dialog";
-import { HttpClient } from "@angular/common/http";
+import { HttpClient, HttpResponse } from "@angular/common/http";
 import {EntityAction} from "./EntityAction";
 import {environment} from "../../../../../environment";
 import {SchoolViewComponent} from "../schools/school-view/school-view.component";
@@ -32,8 +32,11 @@ export class CrudActions {
    * Fetch records
    * @param entity
    */
-  getRecord(entity: EntityAction): Observable<any> {
-    return this.http.get(environment.apiUrl.concat(entity.name).concat("?page=0&size=20"));
+  getRecord(entity: EntityAction, page = 0, size = 20): Observable<HttpResponse<any>> {
+    return this.http.get<any>(
+      environment.apiUrl + entity.name + `?page=${page}&size=${size}`,
+      { observe: 'response' }
+    );
   }
 
 

--- a/src/app/pages/apps/reusable/crud-data-table/crud-data-table.component.html
+++ b/src/app/pages/apps/reusable/crud-data-table/crud-data-table.component.html
@@ -69,6 +69,7 @@
       </table>
       <mat-paginator
         [length]="totalRecords"
+        [pageSize]="10"
         [pageSizeOptions]="[5, 10, 20]"
         showFirstLastButtons
         (page)="pageChange.emit({ page: $event.pageIndex, size: $event.pageSize })">

--- a/src/app/pages/apps/reusable/crud-data-table/crud-data-table.component.html
+++ b/src/app/pages/apps/reusable/crud-data-table/crud-data-table.component.html
@@ -28,7 +28,7 @@
       <table mat-table [dataSource]="tableData" class="mat-elevation-z8">
         <!-- Dynamically generate table headers -->
         <ng-container *ngFor="let column of displayedColumns" [matColumnDef]="column">
-          <th mat-header-cell *matHeaderCellDef class="f-s-16 f-w-600">{{ column | titlecase }}</th>
+          <th mat-header-cell *matHeaderCellDef class="f-s-16 f-w-600">{{ column | camelToTitle }}</th>
           <div *ngIf="column !== 'action'">
             <td mat-cell *matCellDef="let element">{{ element[column] }}</td>
           </div>
@@ -68,9 +68,11 @@
 
       </table>
       <mat-paginator
+        [length]="totalRecords"
         [pageSizeOptions]="[5, 10, 20]"
         showFirstLastButtons
-      ></mat-paginator>
+        (page)="pageChange.emit({ page: $event.pageIndex, size: $event.pageSize })">
+      </mat-paginator>
     </div>
   </mat-card-content>
 </mat-card>

--- a/src/app/pages/apps/reusable/crud-data-table/crud-data-table.component.ts
+++ b/src/app/pages/apps/reusable/crud-data-table/crud-data-table.component.ts
@@ -28,6 +28,7 @@ export class CrudDataTableComponent implements AfterViewInit {
   @Input() tableData: any[] = [];
   @Input() displayedColumns: string[] = [];
   @Input() tableHeading: string;
+  @Input() totalRecords: number = 0;
 
   searchText: any;
 
@@ -37,6 +38,7 @@ export class CrudDataTableComponent implements AfterViewInit {
   @Output() onViewItem = new EventEmitter<any>();
   @Output() onUpdateItem = new EventEmitter<any>();
   @Output() onDeleteItem = new EventEmitter<any>();
+  @Output() pageChange = new EventEmitter<{ page: number; size: number }>();
 
 
   dataSource = new MatTableDataSource();

--- a/src/app/pages/apps/school-stuff/school-stuff.component.html
+++ b/src/app/pages/apps/school-stuff/school-stuff.component.html
@@ -7,7 +7,9 @@
                      (onAddItem)="onAddItem($event)"
                      (onUpdateItem)="onUpdateItem($event)"
                      (onDeleteItem)="onDeleteItem($event)"
-></app-crud-data-table>
+  [totalRecords]="totalRecords"
+  (pageChange)="onPageChange($event)">
+</app-crud-data-table>
 
 
 

--- a/src/app/pages/apps/school-stuff/school-stuff.component.ts
+++ b/src/app/pages/apps/school-stuff/school-stuff.component.ts
@@ -128,13 +128,15 @@ export class SchoolStuffComponent extends CrudActions implements OnInit {
    * @param record
    */
   onFilterValue(record: any) {
+    this.currentPage = 0;
     let entity: EntityAction = {
       name: this.entityName,
       id: '',
       data: record
     };
-    this.onFilterRecord(entity).subscribe((response) => {
-      this.tableData = response
+    this.onFilterRecord(entity, 0, this.pageSize).subscribe(response => {
+      this.tableData = response.body;
+      this.totalRecords = Number(response.headers.get('X-Total-Count') ?? 0);
     });
   }
 

--- a/src/app/pages/apps/school-stuff/school-stuff.component.ts
+++ b/src/app/pages/apps/school-stuff/school-stuff.component.ts
@@ -37,7 +37,7 @@ export class SchoolStuffComponent extends CrudActions implements OnInit {
   tableData: any[];
   totalRecords = 0;
   currentPage = 0;
-  pageSize = 20;
+  pageSize = 10;
   entityName: string = 'school-staffs';
 
   constructor(http: HttpClient, dialog: MatDialog) {

--- a/src/app/pages/apps/school-stuff/school-stuff.component.ts
+++ b/src/app/pages/apps/school-stuff/school-stuff.component.ts
@@ -35,6 +35,9 @@ export class SchoolStuffComponent extends CrudActions implements OnInit {
   displayedColumns: string[];
   tableHeading: string;
   tableData: any[];
+  totalRecords = 0;
+  currentPage = 0;
+  pageSize = 20;
   entityName: string = 'school-staffs';
 
   constructor(http: HttpClient, dialog: MatDialog) {
@@ -49,15 +52,22 @@ export class SchoolStuffComponent extends CrudActions implements OnInit {
   }
 
   // Fetch schools from the backend
-  getRecords() {
+  getRecords(page = this.currentPage, size = this.pageSize) {
     let entity: EntityAction = {
       name: this.entityName,
       id: '',
       data: ''
     };
-    this.getRecord(entity).subscribe((response) => {
-      this.tableData = response
+    this.getRecord(entity, page, size).subscribe(response => {
+      this.tableData = response.body;
+      this.totalRecords = Number(response.headers.get('X-Total-Count') ?? 0);
     });
+  }
+
+  onPageChange(event: { page: number; size: number }) {
+    this.currentPage = event.page;
+    this.pageSize = event.size;
+    this.getRecords(event.page, event.size);
   }
 
   /**

--- a/src/app/pages/apps/schools/schools.component.html
+++ b/src/app/pages/apps/schools/schools.component.html
@@ -6,5 +6,7 @@
   (onViewItem)="onViewItem($event)"
   (onAddItem)="onAddItem($event)"
   (onUpdateItem)="onUpdateItem($event)"
-  (onDeleteItem)="onDeleteItem($event)">
+  (onDeleteItem)="onDeleteItem($event)"
+  [totalRecords]="totalRecords"
+  (pageChange)="onPageChange($event)">
 </app-crud-data-table>

--- a/src/app/pages/apps/schools/schools.component.ts
+++ b/src/app/pages/apps/schools/schools.component.ts
@@ -17,6 +17,9 @@ export class SchoolsComponent extends CrudActions implements OnInit {
   displayedColumns: string[];
   tableHeading: string;
   tableData: any[];
+  totalRecords = 0;
+  currentPage = 0;
+  pageSize = 20;
   entityName: string = 'schools';
 
   constructor(http: HttpClient, dialog: MatDialog) {
@@ -31,15 +34,22 @@ export class SchoolsComponent extends CrudActions implements OnInit {
   }
 
   // Fetch schools from the backend
-  getRecords() {
+  getRecords(page = this.currentPage, size = this.pageSize) {
     let entity: EntityAction = {
       name: this.entityName,
       id: '',
       data: ''
     };
-    this.getRecord(entity).subscribe((response) => {
-      this.tableData = response
+    this.getRecord(entity, page, size).subscribe(response => {
+      this.tableData = response.body;
+      this.totalRecords = Number(response.headers.get('X-Total-Count') ?? 0);
     });
+  }
+
+  onPageChange(event: { page: number; size: number }) {
+    this.currentPage = event.page;
+    this.pageSize = event.size;
+    this.getRecords(event.page, event.size);
   }
 
   /**

--- a/src/app/pages/apps/schools/schools.component.ts
+++ b/src/app/pages/apps/schools/schools.component.ts
@@ -110,13 +110,15 @@ export class SchoolsComponent extends CrudActions implements OnInit {
    * @param record
    */
   onFilterValue(record: any) {
+    this.currentPage = 0;
     let entity: EntityAction = {
       name: this.entityName,
       id: '',
       data: record
     };
-    this.onFilterRecord(entity).subscribe((response) => {
-      this.tableData = response
+    this.onFilterRecord(entity, 0, this.pageSize).subscribe(response => {
+      this.tableData = response.body;
+      this.totalRecords = Number(response.headers.get('X-Total-Count') ?? 0);
     });
   }
 

--- a/src/app/pages/apps/schools/schools.component.ts
+++ b/src/app/pages/apps/schools/schools.component.ts
@@ -19,7 +19,7 @@ export class SchoolsComponent extends CrudActions implements OnInit {
   tableData: any[];
   totalRecords = 0;
   currentPage = 0;
-  pageSize = 20;
+  pageSize = 10;
   entityName: string = 'schools';
 
   constructor(http: HttpClient, dialog: MatDialog) {

--- a/src/app/pages/apps/students/students.component.html
+++ b/src/app/pages/apps/students/students.component.html
@@ -7,7 +7,9 @@
                      (onAddItem)="onAddItem($event)"
                      (onUpdateItem)="onUpdateItem($event)"
                      (onDeleteItem)="onDeleteItem($event)"
-></app-crud-data-table>
+  [totalRecords]="totalRecords"
+  (pageChange)="onPageChange($event)">
+</app-crud-data-table>
 
 
 

--- a/src/app/pages/apps/students/students.component.ts
+++ b/src/app/pages/apps/students/students.component.ts
@@ -84,7 +84,7 @@ export class StudentsComponent extends CrudActions implements OnInit {
   tableData: any[];
   totalRecords = 0;
   currentPage = 0;
-  pageSize = 20;
+  pageSize = 10;
   entityName: string = 'students';
 
   constructor(http: HttpClient, dialog: MatDialog, private ngZone: NgZone) {

--- a/src/app/pages/apps/students/students.component.ts
+++ b/src/app/pages/apps/students/students.component.ts
@@ -175,13 +175,15 @@ export class StudentsComponent extends CrudActions implements OnInit {
    * @param record
    */
   onFilterValue(record: any) {
+    this.currentPage = 0;
     let entity: EntityAction = {
       name: this.entityName,
       id: '',
       data: record
     };
-    this.onFilterRecord(entity).subscribe((response) => {
-      this.tableData = response
+    this.onFilterRecord(entity, 0, this.pageSize).subscribe(response => {
+      this.tableData = response.body;
+      this.totalRecords = Number(response.headers.get('X-Total-Count') ?? 0);
     });
   }
 

--- a/src/app/pages/apps/students/students.component.ts
+++ b/src/app/pages/apps/students/students.component.ts
@@ -82,6 +82,9 @@ export class StudentsComponent extends CrudActions implements OnInit {
   displayedColumns: string[];
   tableHeading: string;
   tableData: any[];
+  totalRecords = 0;
+  currentPage = 0;
+  pageSize = 20;
   entityName: string = 'students';
 
   constructor(http: HttpClient, dialog: MatDialog, private ngZone: NgZone) {
@@ -96,15 +99,22 @@ export class StudentsComponent extends CrudActions implements OnInit {
   }
 
   // Fetch schools from the backend
-  getRecords() {
+  getRecords(page = this.currentPage, size = this.pageSize) {
     let entity: EntityAction = {
       name: this.entityName,
       id: '',
       data: ''
     };
-    this.getRecord(entity).subscribe((response) => {
-      this.tableData = response
+    this.getRecord(entity, page, size).subscribe(response => {
+      this.tableData = response.body;
+      this.totalRecords = Number(response.headers.get('X-Total-Count') ?? 0);
     });
+  }
+
+  onPageChange(event: { page: number; size: number }) {
+    this.currentPage = event.page;
+    this.pageSize = event.size;
+    this.getRecords(event.page, event.size);
   }
 
   /**

--- a/src/app/pages/apps/terminals/terminals.component.html
+++ b/src/app/pages/apps/terminals/terminals.component.html
@@ -8,7 +8,9 @@
                      (onAddItem)="onAddItem($event)"
                      (onUpdateItem)="onUpdateItem($event)"
                      (onDeleteItem)="onDeleteItem($event)"
-></app-crud-data-table>
+  [totalRecords]="totalRecords"
+  (pageChange)="onPageChange($event)">
+</app-crud-data-table>
 
 
 

--- a/src/app/pages/apps/terminals/terminals.component.ts
+++ b/src/app/pages/apps/terminals/terminals.component.ts
@@ -19,7 +19,7 @@ export class TerminalsComponent extends CrudActions implements OnInit {
   tableData: any[];
   totalRecords = 0;
   currentPage = 0;
-  pageSize = 20;
+  pageSize = 10;
   entityName: string = 'terminals';
 
   constructor(http: HttpClient, dialog: MatDialog, private router: Router) {

--- a/src/app/pages/apps/terminals/terminals.component.ts
+++ b/src/app/pages/apps/terminals/terminals.component.ts
@@ -17,6 +17,9 @@ export class TerminalsComponent extends CrudActions implements OnInit {
   displayedColumns: string[];
   tableHeading: string;
   tableData: any[];
+  totalRecords = 0;
+  currentPage = 0;
+  pageSize = 20;
   entityName: string = 'terminals';
 
   constructor(http: HttpClient, dialog: MatDialog, private router: Router) {
@@ -31,15 +34,22 @@ export class TerminalsComponent extends CrudActions implements OnInit {
   }
 
   // Fetch schools from the backend
-  getRecords() {
+  getRecords(page = this.currentPage, size = this.pageSize) {
     let entity: EntityAction = {
       name: this.entityName,
       id: '',
       data: ''
     };
-    this.getRecord(entity).subscribe((response) => {
-      this.tableData = response
+    this.getRecord(entity, page, size).subscribe(response => {
+      this.tableData = response.body;
+      this.totalRecords = Number(response.headers.get('X-Total-Count') ?? 0);
     });
+  }
+
+  onPageChange(event: { page: number; size: number }) {
+    this.currentPage = event.page;
+    this.pageSize = event.size;
+    this.getRecords(event.page, event.size);
   }
 
   /**

--- a/src/app/pages/apps/terminals/terminals.component.ts
+++ b/src/app/pages/apps/terminals/terminals.component.ts
@@ -111,13 +111,15 @@ export class TerminalsComponent extends CrudActions implements OnInit {
    * @param record
    */
   onFilterValue(record: any) {
+    this.currentPage = 0;
     let entity: EntityAction = {
       name: this.entityName,
       id: '',
       data: record
     };
-    this.onFilterRecord(entity).subscribe((response) => {
-      this.tableData = response
+    this.onFilterRecord(entity, 0, this.pageSize).subscribe(response => {
+      this.tableData = response.body;
+      this.totalRecords = Number(response.headers.get('X-Total-Count') ?? 0);
     });
   }
 

--- a/src/app/pages/apps/trips/trips.component.html
+++ b/src/app/pages/apps/trips/trips.component.html
@@ -7,7 +7,9 @@
                      (onAddItem)="onAddItem($event)"
                      (onUpdateItem)="onUpdateItem($event)"
                      (onDeleteItem)="onDeleteItem($event)"
-></app-crud-data-table>
+  [totalRecords]="totalRecords"
+  (pageChange)="onPageChange($event)">
+</app-crud-data-table>
 
 
 

--- a/src/app/pages/apps/trips/trips.component.ts
+++ b/src/app/pages/apps/trips/trips.component.ts
@@ -32,7 +32,7 @@ export class TripsComponent extends CrudActions implements OnInit {
   tableData: any[];
   totalRecords = 0;
   currentPage = 0;
-  pageSize = 20;
+  pageSize = 10;
   entityName: string = 'trips';
 
   constructor(http: HttpClient, dialog: MatDialog, private router: Router) {

--- a/src/app/pages/apps/trips/trips.component.ts
+++ b/src/app/pages/apps/trips/trips.component.ts
@@ -30,6 +30,9 @@ export class TripsComponent extends CrudActions implements OnInit {
   displayedColumns: string[];
   tableHeading: string;
   tableData: any[];
+  totalRecords = 0;
+  currentPage = 0;
+  pageSize = 20;
   entityName: string = 'trips';
 
   constructor(http: HttpClient, dialog: MatDialog, private router: Router) {
@@ -44,15 +47,22 @@ export class TripsComponent extends CrudActions implements OnInit {
   }
 
   // Fetch schools from the backend
-  getRecords() {
+  getRecords(page = this.currentPage, size = this.pageSize) {
     let entity: EntityAction = {
       name: this.entityName,
       id: '',
       data: ''
     };
-    this.getRecord(entity).subscribe((response) => {
-      this.tableData = response
+    this.getRecord(entity, page, size).subscribe(response => {
+      this.tableData = response.body;
+      this.totalRecords = Number(response.headers.get('X-Total-Count') ?? 0);
     });
+  }
+
+  onPageChange(event: { page: number; size: number }) {
+    this.currentPage = event.page;
+    this.pageSize = event.size;
+    this.getRecords(event.page, event.size);
   }
 
   /**

--- a/src/app/pages/apps/trips/trips.component.ts
+++ b/src/app/pages/apps/trips/trips.component.ts
@@ -126,13 +126,15 @@ export class TripsComponent extends CrudActions implements OnInit {
    * @param record
    */
   onFilterValue(record: any) {
+    this.currentPage = 0;
     let entity: EntityAction = {
       name: this.entityName,
       id: '',
       data: record
     };
-    this.onFilterRecord(entity).subscribe((response) => {
-      this.tableData = response
+    this.onFilterRecord(entity, 0, this.pageSize).subscribe(response => {
+      this.tableData = response.body;
+      this.totalRecords = Number(response.headers.get('X-Total-Count') ?? 0);
     });
   }
 

--- a/src/app/pages/apps/vehicles/vehicles.component.html
+++ b/src/app/pages/apps/vehicles/vehicles.component.html
@@ -8,7 +8,9 @@
                      (onAddItem)="onAddItem($event)"
                      (onUpdateItem)="onUpdateItem($event)"
                      (onDeleteItem)="onDeleteItem($event)"
-></app-crud-data-table>
+  [totalRecords]="totalRecords"
+  (pageChange)="onPageChange($event)">
+</app-crud-data-table>
 
 
 

--- a/src/app/pages/apps/vehicles/vehicles.component.ts
+++ b/src/app/pages/apps/vehicles/vehicles.component.ts
@@ -30,6 +30,9 @@ export class VehiclesComponent extends CrudActions implements OnInit {
   displayedColumns: string[];
   tableHeading: string;
   tableData: any[];
+  totalRecords = 0;
+  currentPage = 0;
+  pageSize = 20;
   entityName: string = 'fleets';
 
   constructor(http: HttpClient, dialog: MatDialog) {
@@ -44,15 +47,22 @@ export class VehiclesComponent extends CrudActions implements OnInit {
   }
 
   // Fetch schools from the backend
-  getRecords() {
+  getRecords(page = this.currentPage, size = this.pageSize) {
     let entity: EntityAction = {
       name: this.entityName,
       id: '',
       data: ''
     };
-    this.getRecord(entity).subscribe((response) => {
-      this.tableData = response
+    this.getRecord(entity, page, size).subscribe(response => {
+      this.tableData = response.body;
+      this.totalRecords = Number(response.headers.get('X-Total-Count') ?? 0);
     });
+  }
+
+  onPageChange(event: { page: number; size: number }) {
+    this.currentPage = event.page;
+    this.pageSize = event.size;
+    this.getRecords(event.page, event.size);
   }
 
   /**

--- a/src/app/pages/apps/vehicles/vehicles.component.ts
+++ b/src/app/pages/apps/vehicles/vehicles.component.ts
@@ -123,13 +123,15 @@ export class VehiclesComponent extends CrudActions implements OnInit {
    * @param record
    */
   onFilterValue(record: any) {
+    this.currentPage = 0;
     let entity: EntityAction = {
       name: this.entityName,
       id: '',
       data: record
     };
-    this.onFilterRecord(entity).subscribe((response) => {
-      this.tableData = response
+    this.onFilterRecord(entity, 0, this.pageSize).subscribe(response => {
+      this.tableData = response.body;
+      this.totalRecords = Number(response.headers.get('X-Total-Count') ?? 0);
     });
   }
 

--- a/src/app/pages/apps/vehicles/vehicles.component.ts
+++ b/src/app/pages/apps/vehicles/vehicles.component.ts
@@ -32,7 +32,7 @@ export class VehiclesComponent extends CrudActions implements OnInit {
   tableData: any[];
   totalRecords = 0;
   currentPage = 0;
-  pageSize = 20;
+  pageSize = 10;
   entityName: string = 'fleets';
 
   constructor(http: HttpClient, dialog: MatDialog) {

--- a/src/app/pipe/camel-to-title.pipe.ts
+++ b/src/app/pipe/camel-to-title.pipe.ts
@@ -1,0 +1,15 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'camelToTitle',
+  standalone: false
+})
+export class CamelToTitlePipe implements PipeTransform {
+  transform(value: string): string {
+    if (!value) return value;
+    return value
+      .replace(/([A-Z])/g, ' $1')
+      .replace(/^./, s => s.toUpperCase())
+      .trim();
+  }
+}


### PR DESCRIPTION
## Summary

- **Pagination**: Connected `MatPaginator` to JHipster's `X-Total-Count` response header across all 10 entity data tables (schools, students, drivers, guardians, vehicles, school staff, terminals, trips, organizations, invoices). `CrudActions.getRecord()` now uses `observe:'response'`; each entity tracks `totalRecords`, `currentPage`, and `pageSize` (default 10).
- **Filter pagination**: Search filter also updates the paginator total count and resets to page 0 on each new filter.
- **Column headers**: Added `CamelToTitlePipe` to split camelCase column names — `entityStatus` → `Entity Status`, `classLevel` → `Class Level`, etc.

## Test plan

- [ ] Navigate to any entity table — paginator shows correct total record count
- [ ] Click next page — new records load from the server
- [ ] Change page size dropdown (5/10/20) — row count updates accordingly
- [ ] Type in the search box — paginator total updates to match filtered results
- [ ] Confirm column headers display as `Entity Status`, `Class Level`, `Billing Status` etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)