### PR TITLE
feat: user profile picture, status badges, and sidebar logout

### DIFF
--- a/src/app/layouts/full/vertical/header/header.component.html
+++ b/src/app/layouts/full/vertical/header/header.component.html
@@ -159,7 +159,8 @@
     aria-label="Notifications"
   >
     <img
-      src="/assets/images/profile/profile.png"
+      [src]="profileImageUrl"
+      (error)="profileImageUrl = 'assets/images/profile/user-avatar.png'"
       class="rounded-circle object-cover"
       width="35"
     />
@@ -174,8 +175,9 @@
 
         <div class="d-flex align-items-center p-b-24 b-b-1 m-t-16">
           <img
-            src="/assets/images/profile/profile.png"
-            class="rounded-circle"
+            [src]="profileImageUrl"
+            (error)="profileImageUrl = 'assets/images/profile/user-avatar.png'"
+            class="rounded-circle object-cover"
             width="95"
           />
           <div class="m-l-16">

--- a/src/app/layouts/full/vertical/header/header.component.ts
+++ b/src/app/layouts/full/vertical/header/header.component.ts
@@ -78,6 +78,7 @@ export class HeaderComponent implements OnInit {
   displayUsername = '';
   displayEmail = '';
   displayRole = '';
+  profileImageUrl = 'assets/images/profile/user-avatar.png';
 
   private readonly roleLabels: Record<string, string> = {
     ROLE_ADMIN: 'Administrator',
@@ -135,6 +136,7 @@ export class HeaderComponent implements OnInit {
       next: (acc) => {
         this.displayUsername = acc.login || this.displayUsername;
         this.displayEmail = acc.email;
+        if (acc.imageUrl) this.profileImageUrl = acc.imageUrl;
         this.syncPlaceholderEmail(acc);
       },
     });

--- a/src/app/layouts/full/vertical/sidebar/logout-confirm-dialog.component.ts
+++ b/src/app/layouts/full/vertical/sidebar/logout-confirm-dialog.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+import { MaterialModule } from 'src/app/material.module';
+
+@Component({
+  selector: 'app-logout-confirm-dialog',
+  standalone: true,
+  imports: [MaterialModule],
+  template: `
+    <h2 mat-dialog-title>Confirm Logout</h2>
+    <mat-dialog-content>Are you sure you want to log out?</mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-stroked-button [mat-dialog-close]="false">Cancel</button>
+      <button mat-flat-button color="warn" [mat-dialog-close]="true" class="m-l-8">Logout</button>
+    </mat-dialog-actions>
+  `
+})
+export class LogoutConfirmDialogComponent {}

--- a/src/app/layouts/full/vertical/sidebar/sidebar.component.html
+++ b/src/app/layouts/full/vertical/sidebar/sidebar.component.html
@@ -1,61 +1,16 @@
 <div class="flex">
-  <div
-    class="user-profile profile-bar"
-    style="background: url(assets/images/backgrounds/user-info.jpg) no-repeat"
-  >
-    <!-- User profile image
-    <div class="profile-img">
-      <img
-        src="assets/images/profile/profile.png"
-        alt="user"
-        width="50"
-        class="rounded-circle"
-      />
-    </div>
-    -->
-    <!-- User profile text-->
-    <!-- ============================================================== -->
-    <!-- Profile - style you can find in header.scss -->
-    <!-- ============================================================== -
-    <div class="profile-text">
-      <a
-        [matMenuTriggerFor]="sdprofile"
-        class="d-flex align-items-center text-white w-100 f-s-16"
-      >
-        Markarn Doe
-        <i-tabler name="chevron-down" class="icon-18 m-l-auto"></i-tabler>
-      </a>
-    </div>
-    <mat-menu
-      #sdprofile="matMenu"
-      xPosition="after"
-      class="cardWithShadow profile-dd"
-    >
-      <button mat-menu-item>
-        <mat-icon class="d-flex align-items-center"
-          ><i-tabler name="settings" class="icon-18 d-flex"></i-tabler
-        ></mat-icon>
-        Settings
-      </button>
-      <button mat-menu-item>
-        <mat-icon class="d-flex align-items-center"
-          ><i-tabler name="users" class="icon-18 d-flex"></i-tabler
-        ></mat-icon>
-        Profile
-      </button>
-      <button mat-menu-item>
-        <mat-icon class="d-flex align-items-center"
-          ><i-tabler name="bell-off" class="icon-18 d-flex"></i-tabler
-        ></mat-icon>
-        Disable notifications
-      </button>
-      <a mat-menu-item [routerLink]="['/authentication/side-login']"
-        ><mat-icon class="d-flex align-items-center"
-          ><i-tabler name="logout" class="icon-18 d-flex"></i-tabler
-        ></mat-icon>
-        Sign Out</a
-      >
-    </mat-menu>
-    -->
+  <div class="sidebar-footer b-t-1 p-16 d-flex align-items-center gap-8">
+    <img
+      [src]="profileImageUrl"
+      (error)="profileImageUrl = 'assets/images/profile/user-avatar.png'"
+      class="rounded-circle object-cover"
+      width="36"
+      height="36"
+      alt="profile"
+    />
+    <span class="f-s-14 f-w-600 flex-grow-1 text-truncate">{{ displayUsername }}</span>
+    <button mat-icon-button (click)="confirmLogout()" matTooltip="Logout">
+      <i-tabler name="logout" class="icon-20 d-flex"></i-tabler>
+    </button>
   </div>
 </div>

--- a/src/app/layouts/full/vertical/sidebar/sidebar.component.ts
+++ b/src/app/layouts/full/vertical/sidebar/sidebar.component.ts
@@ -1,13 +1,15 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-
 import { NavService } from '../../../../services/nav.service';
 import { NgScrollbarModule } from 'ngx-scrollbar';
 import { TablerIconsModule } from 'angular-tabler-icons';
 import { MaterialModule } from 'src/app/material.module';
 import { RouterModule } from '@angular/router';
 import { AppNavItemComponent } from './nav-item/nav-item.component';
-
+import { AuthService } from '../../../../services/auth.service';
+import { AccountService } from '../../../../services/account.service';
+import { MatDialog } from '@angular/material/dialog';
+import { LogoutConfirmDialogComponent } from './logout-confirm-dialog.component';
 
 @Component({
     selector: 'app-sidebar',
@@ -16,14 +18,35 @@ import { AppNavItemComponent } from './nav-item/nav-item.component';
         TablerIconsModule,
         MaterialModule,
         RouterModule,
-        AppNavItemComponent, CommonModule
+        AppNavItemComponent,
+        CommonModule
     ],
     templateUrl: './sidebar.component.html'
 })
 export class SidebarComponent implements OnInit {
   navopt = this.navService.showClass;
+  displayUsername = '';
+  profileImageUrl = 'assets/images/profile/user-avatar.png';
 
-  constructor(public navService: NavService) {}
+  constructor(
+    public navService: NavService,
+    private authService: AuthService,
+    private accountService: AccountService,
+    private dialog: MatDialog
+  ) {}
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.displayUsername = this.authService.getUsername();
+    this.accountService.getAccount().subscribe(acc => {
+      this.displayUsername = acc.login || this.displayUsername;
+      if (acc.imageUrl) this.profileImageUrl = acc.imageUrl;
+    });
+  }
+
+  confirmLogout(): void {
+    this.dialog.open(LogoutConfirmDialogComponent, { width: '360px' })
+      .afterClosed().subscribe(confirmed => {
+        if (confirmed) this.authService.logout();
+      });
+  }
 }

--- a/src/app/pages/apps/forms/driver-registration-form-config.ts
+++ b/src/app/pages/apps/forms/driver-registration-form-config.ts
@@ -5,9 +5,8 @@ export const driverForm: IForm = {
   saveBtnTitle: 'Save Driver',
   resetBtnTitle: 'Cancel',
   displayColumns: [
-    'id',
+    'profile',
     'name',
-    //'logoImageUrl',
     'phoneNumber',
     'entityStatus',
     'action',

--- a/src/app/pages/apps/forms/guardian-registration-form-config.ts
+++ b/src/app/pages/apps/forms/guardian-registration-form-config.ts
@@ -5,7 +5,7 @@ export const guardianForm: IForm = {
   saveBtnTitle: 'Add Guardian',
   resetBtnTitle: 'Cancel',
   displayColumns: [
-    'id',
+    'profile',
     'name',
     'guardianType',
     'phoneNumber',

--- a/src/app/pages/apps/forms/student-registration-form-config.ts
+++ b/src/app/pages/apps/forms/student-registration-form-config.ts
@@ -7,9 +7,8 @@ export const studentForm: IForm = {
   saveBtnTitle: 'Add Student',
   resetBtnTitle: 'Cancel',
   displayColumns: [
-    'id',
+    'profile',
     'name',
-    //'logoImageUrl',
     'classLevel',
     'billingStatus',
     'entityStatus',

--- a/src/app/pages/apps/reusable/crud-data-table/crud-data-table.component.html
+++ b/src/app/pages/apps/reusable/crud-data-table/crud-data-table.component.html
@@ -29,8 +29,97 @@
         <!-- Dynamically generate table headers -->
         <ng-container *ngFor="let column of displayedColumns" [matColumnDef]="column">
           <th mat-header-cell *matHeaderCellDef class="f-s-16 f-w-600">{{ column | camelToTitle }}</th>
+
           <div *ngIf="column !== 'action'">
-            <td mat-cell *matCellDef="let element">{{ element[column] }}</td>
+            <td mat-cell *matCellDef="let element">
+              <ng-container [ngSwitch]="column">
+
+                <!-- Profile thumbnail -->
+                <ng-container *ngSwitchCase="'profile'">
+                  <img
+                    [src]="element['profileImageUrl'] || 'assets/images/profile/user-avatar.png'"
+                    (error)="$any($event.target).src = 'assets/images/profile/user-avatar.png'"
+                    class="rounded-circle object-cover"
+                    width="36"
+                    height="36"
+                    alt="profile"
+                  />
+                </ng-container>
+
+                <!-- entityStatus badge -->
+                <ng-container *ngSwitchCase="'entityStatus'">
+                  <span class="badge rounded-pill f-s-12"
+                    [class.bg-light-success]="element[column] === 'ACTIVE'"
+                    [class.text-success]="element[column] === 'ACTIVE'"
+                    [class.bg-light-error]="element[column] === 'INACTIVE'"
+                    [class.text-error]="element[column] === 'INACTIVE'">
+                    {{ element[column] | camelToTitle }}
+                  </span>
+                </ng-container>
+
+                <!-- billingStatus badge -->
+                <ng-container *ngSwitchCase="'billingStatus'">
+                  <span class="badge rounded-pill f-s-12"
+                    [class.bg-light-success]="element[column] === 'ACTIVE'"
+                    [class.text-success]="element[column] === 'ACTIVE'"
+                    [class.bg-light-error]="element[column] === 'OVERDUE'"
+                    [class.text-error]="element[column] === 'OVERDUE'"
+                    [class.bg-secondary]="element[column] === 'INACTIVE'">
+                    {{ element[column] | camelToTitle }}
+                  </span>
+                </ng-container>
+
+                <!-- terminal status badge -->
+                <ng-container *ngSwitchCase="'status'">
+                  <span class="badge rounded-pill f-s-12"
+                    [class.bg-light-success]="element[column] === 'ONLINE'"
+                    [class.text-success]="element[column] === 'ONLINE'"
+                    [class.bg-light-error]="element[column] === 'OFFLINE'"
+                    [class.text-error]="element[column] === 'OFFLINE'">
+                    {{ element[column] | camelToTitle }}
+                  </span>
+                </ng-container>
+
+                <!-- tripType badge -->
+                <ng-container *ngSwitchCase="'tripType'">
+                  <span class="badge rounded-pill f-s-12"
+                    [class.bg-light-primary]="element[column] === 'PICKUP'"
+                    [class.text-primary]="element[column] === 'PICKUP'"
+                    [class.bg-light-warning]="element[column] === 'DROPOFF'"
+                    [class.text-warning]="element[column] === 'DROPOFF'"
+                    [class.bg-secondary]="element[column] === 'FIELDTRIP'">
+                    {{ element[column] | camelToTitle }}
+                  </span>
+                </ng-container>
+
+                <!-- tripStatus badge -->
+                <ng-container *ngSwitchCase="'tripStatus'">
+                  <span class="badge rounded-pill f-s-12"
+                    [class.bg-light-warning]="element[column] === 'STARTED'"
+                    [class.text-warning]="element[column] === 'STARTED'"
+                    [class.bg-light-primary]="element[column] === 'ONGOING'"
+                    [class.text-primary]="element[column] === 'ONGOING'"
+                    [class.bg-light-success]="element[column] === 'COMPLETED'"
+                    [class.text-success]="element[column] === 'COMPLETED'">
+                    {{ element[column] | camelToTitle }}
+                  </span>
+                </ng-container>
+
+                <!-- date/time columns -->
+                <ng-container *ngSwitchCase="'creationDate'">{{ element[column] | date:'dd MMM yyyy, HH:mm' }}</ng-container>
+                <ng-container *ngSwitchCase="'modifiedDate'">{{ element[column] | date:'dd MMM yyyy, HH:mm' }}</ng-container>
+                <ng-container *ngSwitchCase="'startTime'">{{ element[column] | date:'dd MMM yyyy, HH:mm' }}</ng-container>
+                <ng-container *ngSwitchCase="'endTime'">{{ element[column] | date:'dd MMM yyyy, HH:mm' }}</ng-container>
+                <ng-container *ngSwitchCase="'lastPing'">{{ element[column] | date:'dd MMM yyyy, HH:mm' }}</ng-container>
+                <ng-container *ngSwitchCase="'pickupTime'">{{ element[column] | date:'dd MMM yyyy, HH:mm' }}</ng-container>
+                <ng-container *ngSwitchCase="'dropOffTime'">{{ element[column] | date:'dd MMM yyyy, HH:mm' }}</ng-container>
+                <ng-container *ngSwitchCase="'nextBillingCycle'">{{ element[column] | date:'dd MMM yyyy' }}</ng-container>
+
+                <!-- default: plain text through the pipe for clean casing -->
+                <ng-container *ngSwitchDefault>{{ element[column] }}</ng-container>
+
+              </ng-container>
+            </td>
           </div>
 
           <div *ngIf="column == 'action'">
@@ -39,15 +128,13 @@
                 (click)="actionRecord('View', element)"
                 class="m-r-10 cursor-pointer"
               >
-                <i-tabler name="eye" class="icon-18"></i-tabler
-                >
+                <i-tabler name="eye" class="icon-18"></i-tabler>
               </a>
               <a
                 (click)="actionRecord('Update', element)"
                 class="m-r-10 cursor-pointer"
               >
-                <i-tabler name="edit" class="icon-18"></i-tabler
-                >
+                <i-tabler name="edit" class="icon-18"></i-tabler>
               </a>
               <a
                 (click)="actionRecord('Delete', element)"

--- a/src/app/pipe/camel-to-title.pipe.ts
+++ b/src/app/pipe/camel-to-title.pipe.ts
@@ -7,6 +7,13 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class CamelToTitlePipe implements PipeTransform {
   transform(value: string): string {
     if (!value) return value;
+    // SCREAMING_SNAKE_CASE → Title Case  (GRADE_1 → Grade 1, PICKUP → Pickup)
+    if (/^[A-Z0-9_]+$/.test(value)) {
+      return value.replace(/_/g, ' ')
+        .toLowerCase()
+        .replace(/\b\w/g, s => s.toUpperCase());
+    }
+    // camelCase → Title Case  (entityStatus → Entity Status)
     return value
       .replace(/([A-Z])/g, ' $1')
       .replace(/^./, s => s.toUpperCase())

--- a/src/app/services/account.service.ts
+++ b/src/app/services/account.service.ts
@@ -8,6 +8,7 @@ export interface AccountInfo {
   firstName: string;
   lastName: string;
   email: string;
+  imageUrl?: string;
   langKey: string;
   authorities: string[];
 }


### PR DESCRIPTION
## Summary

- **User profile picture**: Header toolbar and dropdown now load the real user avatar from `/api/account`; falls back to `user-avatar.png` if `imageUrl` is blank (default for Keycloak SSO users) or broken
- **Data table beautification**: Status columns (`entityStatus`, `billingStatus`, `status`, `tripType`, `tripStatus`) render as colour-coded badge pills; date/time columns formatted as `dd MMM yyyy, HH:mm`; profile thumbnail column added for students, drivers, and guardians tables; `CamelToTitlePipe` extended to handle `SCREAMING_SNAKE_CASE` values (`GRADE_1` → `Grade 1`)
- **Sidebar logout**: New sidebar footer shows avatar + username + logout icon button; clicking logout opens a confirmation modal; confirming calls `AuthService.logout()` and ends the Keycloak session

## Test plan

- [ ] Log in → header toolbar and profile dropdown show avatar placeholder (Keycloak users have no imageUrl by default)
- [ ] Schools table → `Entity Status` column shows green `Active` / red `Inactive` pill badges
- [ ] Trips table → `Trip Type` column shows colour-coded pills (Pickup blue, Dropoff orange, Fieldtrip grey)
- [ ] Students table → `Billing Status` shows green/red pills; first column shows 36px profile thumbnail
- [ ] Terminals table → `Status` column shows Online green / Offline red
- [ ] Date columns (`Creation Date`, `Start Time`, etc.) display as `dd MMM yyyy, HH:mm`
- [ ] Click logout icon in sidebar → confirmation modal appears
- [ ] Click Cancel → modal closes, user stays logged in
- [ ] Click Logout → Keycloak session ends, redirected to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)