### PR TITLE
feat: simplify trip creation form and add driver/plate columns

### DIFF
--- a/src/app/pages/apps/forms/trip-registration-form-config.ts
+++ b/src/app/pages/apps/forms/trip-registration-form-config.ts
@@ -9,6 +9,8 @@ export const tripForm: IForm = {
     'tripStatus',
     'startTime',
     'endTime',
+    'driverName',
+    'numberPlate',
     'action',
   ],
   formControls: [

--- a/src/app/pages/apps/forms/trip-registration-form-config.ts
+++ b/src/app/pages/apps/forms/trip-registration-form-config.ts
@@ -5,8 +5,10 @@ export const tripForm: IForm = {
   saveBtnTitle: 'Save Trip',
   resetBtnTitle: 'Cancel',
   displayColumns: [
-    'id',
     'tripType',
+    'tripStatus',
+    'startTime',
+    'endTime',
     'action',
   ],
   formControls: [
@@ -28,67 +30,6 @@ export const tripForm: IForm = {
           "validatorName": "required",
           "pattern": "",
           "message": "Trip type is required."
-        }
-      ]
-    },
-    {
-      "name": "tripStatus",
-      "label": "Trip Status",
-      "value": "",
-      "placeholder": "Select Trip Status",
-      "class": "col-sm-12 d-flex align-items-center",
-      "type": "select",
-      "displayInput": true,
-      "options": [
-        {"label": "Started", "value": "STARTED"},
-        {"label": "Ongoing", "value": "ONGOING"},
-        {"label": "Completed", "value": "COMPLETED"}
-      ],
-      "validators": [
-        {
-          "validatorName": "required",
-          "pattern": "",
-          "message": "Trip status is required."
-        }
-      ]
-    },
-    {
-      "name": "startTime",
-      "label": "Start Time",
-      "value": "",
-      "placeholder": "YYYY-MM-DDTHH:MM",
-      "class": "col-md-6",
-      "type": "datetime-local",
-      "displayInput": true,
-      "validators": []
-    },
-    {
-      "name": "endTime",
-      "label": "End Time",
-      "value": "",
-      "placeholder": "YYYY-MM-DDTHH:MM",
-      "class": "col-md-6",
-      "type": "datetime-local",
-      "displayInput": true,
-      "validators": []
-    },
-    {
-      "name": "driverId",
-      "label": "Driver",
-      "value": "",
-      "placeholder": "Select Driver",
-      "class": "col-sm-12 d-flex align-items-center",
-      "type": "select",
-      "displayInput": true,
-      "options": [],
-      "apiEndpoint": "drivers",
-      "optionLabel": "name",
-      "optionValue": "id",
-      "validators": [
-        {
-          "validatorName": "required",
-          "pattern": "",
-          "message": "Driver is required."
         }
       ]
     }

--- a/src/app/pages/apps/trips/trips.component.html
+++ b/src/app/pages/apps/trips/trips.component.html
@@ -1,19 +1,11 @@
-
 <app-crud-data-table [displayedColumns]="displayedColumns"
                      [tableData]="tableData"
                      [tableHeading]="tableHeading"
-
                      (onViewItem)="onViewItem($event)"
                      (onAddItem)="onAddItem($event)"
                      (onUpdateItem)="onUpdateItem($event)"
                      (onDeleteItem)="onDeleteItem($event)"
-  [totalRecords]="totalRecords"
-  (pageChange)="onPageChange($event)">
+                     (onFilterValue)="onFilterValue($event)"
+                     [totalRecords]="totalRecords"
+                     (pageChange)="onPageChange($event)">
 </app-crud-data-table>
-
-
-
-
-
-
-


### PR DESCRIPTION
## Summary

- Trip creation form now shows only **Trip Type** — `tripStatus`, `startTime`, `endTime`, and `driverId` removed (all set automatically by the backend)
- Trips data table displays: Trip Type, Trip Status, Start Time, End Time, Driver Name, Number Plate
- Search filter wired up on the trips table

🤖 Generated with [Claude Code](https://claude.com/claude-code)