### PR TITLE
fix: trips map routing, Direction button for BOARDED students

### DIFF
--- a/src/app/pages/apps/trips/student-trip/student-trip.component.html
+++ b/src/app/pages/apps/trips/student-trip/student-trip.component.html
@@ -45,7 +45,7 @@
            <button disabled="true"  *ngIf="student.status == 'DROPPED_OFF'" mat-flat-button class="m-r-8" color="disabled">
             Dropped Off
           </button>
-          <button  (click)="actionStudentTrip('direction', student)" *ngIf="student.status == 'PENDING'" mat-flat-button class="m-r-8" color="accent">
+          <button  (click)="actionStudentTrip('direction', student)" *ngIf="student.status == 'PENDING' || student.status == 'BOARDED'" mat-flat-button class="m-r-8" color="accent">
             Direction
           </button>
         </div>

--- a/src/app/pages/apps/trips/trip-viewer/trip-viewer.component.ts
+++ b/src/app/pages/apps/trips/trip-viewer/trip-viewer.component.ts
@@ -18,6 +18,8 @@ export class TripViewerComponent implements OnInit, OnDestroy {
   distance = '';
   busPlateNo = '';
   driverName = '';
+  tripType = '';
+  studentStatus = '';
 
   schoolLocation: google.maps.LatLngLiteral = {lat: -1.286389, lng: 36.817223};
   busLocation: google.maps.LatLngLiteral = {lat: -1.286389, lng: 36.817223};
@@ -79,12 +81,14 @@ export class TripViewerComponent implements OnInit, OnDestroy {
         const terminal = fleet.terminal || {};
         const school = fleet.school || {};
 
+        this.tripType = st.trip?.tripType || '';
+        this.studentStatus = st.status || '';
+
         // Home location
         if (student.latitude && student.longitude) {
           this.homeLocation = {lat: Number(student.latitude), lng: Number(student.longitude)};
           this.center = this.homeLocation;
         }
-        this.destination = student.homeAddress || `${student.name}'s home`;
 
         // School location
         if (school.latitude && school.longitude) {
@@ -136,12 +140,19 @@ export class TripViewerComponent implements OnInit, OnDestroy {
     });
   }
 
+  private getRouteDestination(): google.maps.LatLngLiteral {
+    if (this.studentStatus === 'BOARDED' && this.tripType === 'PICKUP') {
+      return this.schoolLocation;
+    }
+    return this.homeLocation;
+  }
+
   private async calculateRouteAndETA(): Promise<void> {
     return new Promise((resolve) => {
       const directionsService = new google.maps.DirectionsService();
       const request: google.maps.DirectionsRequest = {
         origin: this.busLocation,
-        destination: this.homeLocation,
+        destination: this.getRouteDestination(),
         travelMode: google.maps.TravelMode.DRIVING
       };
       directionsService.route(request, (response, status) => {


### PR DESCRIPTION
## Summary

- Show **Direction** button for students in both `PENDING` and `BOARDED` status (was `PENDING` only)
- Route destination on the trip viewer now depends on trip type and student status:
  - `PENDING` (any trip type): terminal → student's home
  - `BOARDED` + `PICKUP`: terminal → school
  - `BOARDED` + `DROPOFF`: terminal → student's home

## Test plan

- [ ] Open an active PICKUP trip → PENDING student: Direction opens map routing to student's home
- [ ] Pick up a student → Direction button still visible; map now routes to school
- [ ] Open an active DROPOFF trip → BOARDED student: map routes to student's home

🤖 Generated with [Claude Code](https://claude.com/claude-code)