### PR TITLE
fix: use npm install --legacy-peer-deps in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-alpine AS build
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci
+RUN npm install --legacy-peer-deps
 COPY . .
 ARG BUILD_CONFIG=staging
 RUN npx ng build --configuration=${BUILD_CONFIG}


### PR DESCRIPTION
npm ci fails due to peer dependency conflicts with Angular 19. Switching to npm install --legacy-peer-deps.