### PR TITLE
fix: catch Keycloak SSO init error to prevent blank page

### DIFF
--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -15,10 +15,15 @@ export class AuthService {
   constructor(private router: Router, private permissionsService: NgxPermissionsService) {}
 
   async init(): Promise<void> {
-    const authenticated = await this.keycloak.init({ onLoad: 'check-sso', pkceMethod: 'S256' });
-    if (authenticated && this.keycloak.token) {
-      localStorage.setItem('token', this.keycloak.token);
-      this.loadRolesFromToken();
+    try {
+      const authenticated = await this.keycloak.init({ onLoad: 'check-sso', pkceMethod: 'S256' });
+      if (authenticated && this.keycloak.token) {
+        localStorage.setItem('token', this.keycloak.token);
+        this.loadRolesFromToken();
+      }
+    } catch {
+      // Keycloak SSO check failed (e.g. third-party cookie blocked) — app still boots,
+      // AuthGuard will redirect to login if no token exists.
     }
   }
 


### PR DESCRIPTION
## Summary
- `AuthService.init()` ran as `APP_INITIALIZER` and called `keycloak.init({ onLoad: 'check-sso' })`
- If the SSO check fails (third-party cookies blocked, network issue), the promise rejected and Angular never finished bootstrapping → blank page
- Now errors are caught silently; the app always boots and `AuthGuard` redirects unauthenticated users to `/authentication/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)