### PR TITLE
fix: remove check-sso onLoad to fix blank page

### DIFF
--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -16,14 +16,13 @@ export class AuthService {
 
   async init(): Promise<void> {
     try {
-      const authenticated = await this.keycloak.init({ onLoad: 'check-sso', pkceMethod: 'S256' });
+      const authenticated = await this.keycloak.init({ pkceMethod: 'S256' });
       if (authenticated && this.keycloak.token) {
         localStorage.setItem('token', this.keycloak.token);
         this.loadRolesFromToken();
       }
     } catch {
-      // Keycloak SSO check failed (e.g. third-party cookie blocked) — app still boots,
-      // AuthGuard will redirect to login if no token exists.
+      // Keycloak init failed — app still boots, AuthGuard handles redirect to login.
     }
   }
 


### PR DESCRIPTION
## Summary
- `onLoad: 'check-sso'` was triggering a full-page Keycloak redirect before Angular finished bootstrapping → blank page for unauthenticated users
- Removed `onLoad` entirely; Keycloak still processes OAuth2 code exchanges on redirect so Google login continues to work
- `AuthGuard` now handles the redirect to `/authentication/login` cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)